### PR TITLE
feat: [FC-86] Updated Header links

### DIFF
--- a/.env
+++ b/.env
@@ -20,5 +20,8 @@ SITE_NAME=''
 USER_INFO_COOKIE_NAME=''
 APP_ID='catalog'
 MFE_CONFIG_API_URL=''
+ENABLE_PROGRAMS=false
+SUPPORT_URL=''
+INFO_EMAIL=''
 # Fallback in local style files
 PARAGON_THEME_URLS={}

--- a/.env.development
+++ b/.env.development
@@ -21,5 +21,8 @@ SITE_NAME=localhost
 USER_INFO_COOKIE_NAME='edx-user-info'
 APP_ID='catalog'
 MFE_CONFIG_API_URL=''
+ENABLE_PROGRAMS=false
+SUPPORT_URL=''
+INFO_EMAIL='info@example.com'
 # Fallback in local style files
 PARAGON_THEME_URLS={}

--- a/.env.test
+++ b/.env.test
@@ -1,6 +1,7 @@
 ACCESS_TOKEN_COOKIE_NAME='edx-jwt-cookie-header-payload'
 BASE_URL='http://localhost:1998'
 CREDENTIALS_BASE_URL='http://localhost:18150'
+SUPPORT_URL='http://support.example.com'
 CSRF_TOKEN_API_PATH='/csrf/api/v1/token'
 ECOMMERCE_BASE_URL='http://localhost:18130'
 LANGUAGE_PREFERENCE_COOKIE_NAME='openedx-language-preference'
@@ -19,5 +20,7 @@ SITE_NAME=localhost
 USER_INFO_COOKIE_NAME='edx-user-info'
 APP_ID='catalog'
 MFE_CONFIG_API_URL=''
+ENABLE_PROGRAMS=false
+SUPPORT_URL='info@example.com'
 PARAGON_THEME_URLS={}
 INFO_EMAIL=support@example.com

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -24,6 +24,10 @@ jest.mock('./data/course-discovery/hooks', () => ({
   useCourseDiscovery: jest.fn(),
 }));
 
+jest.mock('./header/hooks/useMenuItems', () => ({
+  useMenuItems: jest.fn(() => ([])),
+}));
+
 const mockFrontendParams = useFrontendParams as jest.Mock;
 const mockCourseDiscovery = useCourseDiscovery as jest.Mock;
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,8 +2,8 @@ import { AppProvider } from '@edx/frontend-platform/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { Route, Routes } from 'react-router-dom';
 import { FooterSlot } from '@edx/frontend-component-footer';
-import Header from '@edx/frontend-component-header';
 
+import CatalogHeader from './header/CatalogHeader';
 import HomePage from './home/HomePage';
 import CatalogPage from './сatalog/CatalogPage';
 import CourseAboutPage from './course-about/CourseAboutPage';
@@ -17,7 +17,7 @@ const App = () => (
   <AppProvider>
     <QueryClientProvider client={queryClient}>
       <FrontendParamsProvider>
-        <Header />
+        <CatalogHeader />
         <main className="d-flex flex-column flex-grow-1">
           <Routes>
             <Route path={ROUTES.HOME} element={<HomePage />} />

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -1,0 +1,12 @@
+const configuration = {
+  LMS_BASE_URL: process.env.LMS_BASE_URL,
+  SITE_NAME: process.env.SITE_NAME,
+  // SUPPORT_URL: process.env.SUPPORT_URL || null,
+  INFO_EMAIL: process.env.INFO_EMAIL || '',
+  LOGO_URL: process.env.LOGO_URL,
+  ENABLE_PROGRAMS: process.env.ENABLE_PROGRAMS === 'true',
+};
+
+const features = {};
+
+export { configuration, features };

--- a/src/generic/course-card/CourseCard.test.tsx
+++ b/src/generic/course-card/CourseCard.test.tsx
@@ -1,7 +1,8 @@
 import { getConfig } from '@edx/frontend-platform';
 
-import { mockCourseResponse } from '../../__mocks__';
-import { render, screen } from '../../setupTest';
+import { ROUTES } from '@src/routes';
+import { mockCourseResponse } from '@src/__mocks__';
+import { render, screen } from '@src/setupTest';
 import { CourseCard } from '.';
 
 import messages from './messages';
@@ -38,7 +39,7 @@ describe('CourseCard', () => {
     renderComponent();
 
     const link = screen.getByRole('link');
-    expect(link).toHaveAttribute('href', `/courses/${mockCourseResponse.id}/about`);
+    expect(link).toHaveAttribute('href', ROUTES.COURSE_ABOUT.replace(':courseId', mockCourseResponse.id));
   });
 
   it('handles missing start date gracefully', () => {

--- a/src/generic/course-card/index.tsx
+++ b/src/generic/course-card/index.tsx
@@ -5,6 +5,7 @@ import { useIntl } from '@edx/frontend-platform/i18n';
 import noCourseImg from '@src/assets/images/no-course-image.svg';
 import noOrgImg from '@src/assets/images/no-org-image.svg';
 
+import { ROUTES } from '@src/routes';
 import { CourseCardProps } from './types';
 import messages from './messages';
 import { getFullImageUrl } from './utils';
@@ -23,7 +24,7 @@ export const CourseCard = ({ course }: CourseCardProps) => {
   return (
     <Card
       as={Link}
-      to={`/courses/${course.id}/about`}
+      to={ROUTES.COURSE_ABOUT.replace(':courseId', course.id)}
       className={`course-card ${isExtraSmall ? 'w-100' : 'course-card-desktop'}`}
       isClickable
     >

--- a/src/header/CatalogHeader.test.tsx
+++ b/src/header/CatalogHeader.test.tsx
@@ -1,0 +1,285 @@
+import { getConfig, mergeConfig } from '@edx/frontend-platform';
+import { AppContext } from '@edx/frontend-platform/react';
+
+import { render } from '../setupTest';
+import { ROUTES } from '../routes';
+import CatalogHeader from './CatalogHeader';
+import { useMenuItems } from './hooks/useMenuItems';
+import messages from './messages';
+
+jest.mock('@edx/frontend-platform', () => ({
+  getConfig: jest.fn(() => ({
+    LMS_BASE_URL: process.env.LMS_BASE_URL,
+    ENABLE_PROGRAMS: true,
+    ENABLE_COURSE_DISCOVERY: true,
+  })),
+  ensureConfig: jest.fn(),
+  mergeConfig: jest.fn(),
+}));
+
+jest.mock('@edx/frontend-component-header', () => ({
+  __esModule: true,
+  default: jest.fn(({ mainMenuItems, logoDestination, secondaryMenuItems }) => (
+    <div data-testid="header">
+      <div data-testid="main-menu">{JSON.stringify(mainMenuItems)}</div>
+      <div data-testid="logo-destination">{logoDestination}</div>
+      <div data-testid="secondary-menu">{JSON.stringify(secondaryMenuItems)}</div>
+    </div>
+  )),
+}));
+
+jest.mock('./hooks/useMenuItems', () => ({
+  useMenuItems: jest.fn(),
+}));
+
+describe('CatalogHeader', () => {
+  const mockMenuItems = {
+    mainMenu: [
+      {
+        type: 'item',
+        href: `${getConfig().LMS_BASE_URL}/dashboard`,
+        content: messages.courses.defaultMessage,
+      },
+    ],
+    secondaryMenu: [
+      {
+        type: 'item',
+        href: getConfig().SUPPORT_URL,
+        content: messages.help.defaultMessage,
+      },
+    ],
+    isNotHomePage: false,
+  };
+
+  beforeEach(() => {
+    (useMenuItems as jest.Mock).mockReturnValue(mockMenuItems);
+  });
+
+  afterEach(() => jest.clearAllMocks());
+
+  it('renders header with correct props', () => {
+    const { getByTestId } = render(<CatalogHeader />);
+
+    expect(getByTestId('header')).toBeInTheDocument();
+    expect(getByTestId('main-menu')).toHaveTextContent(JSON.stringify(mockMenuItems.mainMenu));
+    expect(getByTestId('secondary-menu')).toHaveTextContent(JSON.stringify(mockMenuItems.secondaryMenu));
+    expect(getByTestId('logo-destination')).toHaveTextContent(getConfig().LMS_BASE_URL);
+  });
+
+  it('should display Help link if SUPPORT_URL is set', () => {
+    mergeConfig({ SUPPORT_URL: getConfig().SUPPORT_URL });
+    const { getByTestId } = render(<CatalogHeader />);
+    const secondaryMenuText = getByTestId('secondary-menu').textContent;
+    const secondaryMenu = secondaryMenuText ? JSON.parse(secondaryMenuText) : [];
+
+    expect(secondaryMenu).toHaveLength(1);
+    expect(secondaryMenu[0].href).toBe(getConfig().SUPPORT_URL);
+  });
+
+  it('should display Programs link if it is enabled by configuration', () => {
+    const mockMenuItemsWithPrograms = {
+      ...mockMenuItems,
+      mainMenu: [
+        ...mockMenuItems.mainMenu,
+        {
+          type: 'item',
+          href: `${getConfig().LMS_BASE_URL}/programs`,
+          content: messages.programs.defaultMessage,
+        },
+      ],
+    };
+    (useMenuItems as jest.Mock).mockReturnValue(mockMenuItemsWithPrograms);
+
+    const { getByTestId } = render(<CatalogHeader />);
+    const mainMenuText = getByTestId('main-menu').textContent;
+    const mainMenu = mainMenuText ? JSON.parse(mainMenuText) : [];
+
+    expect(mainMenu).toContainEqual(
+      expect.objectContaining({
+        href: expect.stringContaining('/programs'),
+      }),
+    );
+  });
+
+  it('should not display Discover New tab if course discovery is disabled', () => {
+    const mockMenuItemsWithoutDiscovery = {
+      ...mockMenuItems,
+      mainMenu: mockMenuItems.mainMenu.filter(item => !item.href.includes(ROUTES.COURSES)),
+    };
+    (useMenuItems as jest.Mock).mockReturnValue(mockMenuItemsWithoutDiscovery);
+
+    const { getByTestId } = render(<CatalogHeader />);
+    const mainMenuText = getByTestId('main-menu').textContent;
+    const mainMenu = mainMenuText ? JSON.parse(mainMenuText) : [];
+
+    expect(mainMenu).not.toContainEqual(
+      expect.objectContaining({
+        href: expect.stringContaining(ROUTES.COURSES),
+      }),
+    );
+  });
+
+  it('should not display Help link if SUPPORT_URL is not set', () => {
+    mergeConfig({ SUPPORT_URL: undefined });
+    const mockMenuItemsWithoutHelp = {
+      ...mockMenuItems,
+      secondaryMenu: [],
+    };
+    (useMenuItems as jest.Mock).mockReturnValue(mockMenuItemsWithoutHelp);
+
+    const { getByTestId } = render(<CatalogHeader />);
+    const secondaryMenuText = getByTestId('secondary-menu').textContent;
+    const secondaryMenu = secondaryMenuText ? JSON.parse(secondaryMenuText) : [];
+
+    expect(secondaryMenu).toHaveLength(0);
+  });
+
+  it('should display active state for current page menu item', () => {
+    const mockMenuItemsWithActive = {
+      ...mockMenuItems,
+      mainMenu: [
+        {
+          type: 'item',
+          href: `${getConfig().LMS_BASE_URL}/dashboard`,
+          content: messages.courses.defaultMessage,
+          isActive: true,
+        },
+      ],
+    };
+    (useMenuItems as jest.Mock).mockReturnValue(mockMenuItemsWithActive);
+
+    const { getByTestId } = render(<CatalogHeader />);
+    const mainMenuText = getByTestId('main-menu').textContent;
+    const mainMenu = mainMenuText ? JSON.parse(mainMenuText) : [];
+
+    expect(mainMenu[0].isActive).toBe(true);
+  });
+
+  it('should handle empty menu items gracefully', () => {
+    const mockEmptyMenuItems = {
+      mainMenu: [],
+      secondaryMenu: [],
+      isNotHomePage: false,
+    };
+    (useMenuItems as jest.Mock).mockReturnValue(mockEmptyMenuItems);
+
+    const { getByTestId } = render(<CatalogHeader />);
+    const mainMenuText = getByTestId('main-menu').textContent;
+    const secondaryMenuText = getByTestId('secondary-menu').textContent;
+    const mainMenu = mainMenuText ? JSON.parse(mainMenuText) : [];
+    const secondaryMenu = secondaryMenuText ? JSON.parse(secondaryMenuText) : [];
+
+    expect(mainMenu).toHaveLength(0);
+    expect(secondaryMenu).toHaveLength(0);
+  });
+
+  it('should display Explore courses link when course discovery is enabled', () => {
+    const mockMenuItemsWithExploreCourses = {
+      ...mockMenuItems,
+      mainMenu: [
+        ...mockMenuItems.mainMenu,
+        {
+          type: 'item',
+          href: `${getConfig().LMS_BASE_URL}${ROUTES.COURSES}`,
+          content: messages.exploreCourses.defaultMessage,
+          isActive: false,
+        },
+      ],
+    };
+    (useMenuItems as jest.Mock).mockReturnValue(mockMenuItemsWithExploreCourses);
+    mergeConfig({ ENABLE_COURSE_DISCOVERY: true });
+
+    const { getByTestId } = render(<CatalogHeader />);
+    const mainMenuText = getByTestId('main-menu').textContent;
+    const mainMenu = mainMenuText ? JSON.parse(mainMenuText) : [];
+
+    expect(mainMenu).toContainEqual(
+      expect.objectContaining({
+        href: expect.stringContaining(ROUTES.COURSES),
+        content: messages.exploreCourses.defaultMessage,
+      }),
+    );
+  });
+
+  it('should display correct menu items for authenticated user', () => {
+    const authenticatedUser = { username: 'testuser' };
+    const mockMenuItemsForAuth = {
+      mainMenu: [
+        {
+          type: 'item',
+          href: `${getConfig().LMS_BASE_URL}/dashboard`,
+          content: messages.courses.defaultMessage,
+        },
+        {
+          type: 'item',
+          href: `${getConfig().LMS_BASE_URL}/programs`,
+          content: messages.programs.defaultMessage,
+        },
+        {
+          type: 'item',
+          href: `${getConfig().LMS_BASE_URL}${ROUTES.COURSES}`,
+          content: messages.discoverNew.defaultMessage,
+        },
+      ],
+      secondaryMenu: [
+        {
+          type: 'item',
+          href: getConfig().SUPPORT_URL,
+          content: messages.help.defaultMessage,
+        },
+      ],
+      isNotHomePage: false,
+    };
+    (useMenuItems as jest.Mock).mockReturnValue(mockMenuItemsForAuth);
+
+    const { getByTestId } = render(
+      <AppContext.Provider value={{ authenticatedUser }}>
+        <CatalogHeader />
+      </AppContext.Provider>,
+    );
+
+    const mainMenuText = getByTestId('main-menu').textContent;
+    const mainMenu = mainMenuText ? JSON.parse(mainMenuText) : [];
+
+    expect(mainMenu).toHaveLength(3);
+    expect(mainMenu[0].href).toBe(`${getConfig().LMS_BASE_URL}/dashboard`);
+    expect(mainMenu[1].href).toBe(`${getConfig().LMS_BASE_URL}/programs`);
+    expect(mainMenu[2].href).toBe(`${getConfig().LMS_BASE_URL}${ROUTES.COURSES}`);
+  });
+
+  it('should display correct menu items for non-authenticated user', () => {
+    const mockMenuItemsForNonAuth = {
+      mainMenu: [
+        {
+          type: 'item',
+          href: `${getConfig().LMS_BASE_URL}${ROUTES.COURSES}`,
+          content: messages.exploreCourses.defaultMessage,
+          isActive: true,
+        },
+      ],
+      secondaryMenu: [
+        {
+          type: 'item',
+          href: getConfig().SUPPORT_URL,
+          content: messages.help.defaultMessage,
+        },
+      ],
+      isNotHomePage: false,
+    };
+    (useMenuItems as jest.Mock).mockReturnValue(mockMenuItemsForNonAuth);
+
+    const { getByTestId } = render(
+      <AppContext.Provider value={{ authenticatedUser: null }}>
+        <CatalogHeader />
+      </AppContext.Provider>,
+    );
+
+    const mainMenuText = getByTestId('main-menu').textContent;
+    const mainMenu = mainMenuText ? JSON.parse(mainMenuText) : [];
+
+    expect(mainMenu).toHaveLength(1);
+    expect(mainMenu[0].href).toBe(`${getConfig().LMS_BASE_URL}${ROUTES.COURSES}`);
+    expect(mainMenu[0].content).toBe(messages.exploreCourses.defaultMessage);
+    expect(mainMenu[0].isActive).toBe(true);
+  });
+});

--- a/src/header/CatalogHeader.test.tsx
+++ b/src/header/CatalogHeader.test.tsx
@@ -1,7 +1,7 @@
 import { getConfig, mergeConfig } from '@edx/frontend-platform';
 import { AppContext } from '@edx/frontend-platform/react';
 
-import { render } from '../setupTest';
+import { render, screen } from '../setupTest';
 import { ROUTES } from '../routes';
 import CatalogHeader from './CatalogHeader';
 import { useMenuItems } from './hooks/useMenuItems';
@@ -58,18 +58,18 @@ describe('CatalogHeader', () => {
   afterEach(() => jest.clearAllMocks());
 
   it('renders header with correct props', () => {
-    const { getByTestId } = render(<CatalogHeader />);
+    render(<CatalogHeader />);
 
-    expect(getByTestId('header')).toBeInTheDocument();
-    expect(getByTestId('main-menu')).toHaveTextContent(JSON.stringify(mockMenuItems.mainMenu));
-    expect(getByTestId('secondary-menu')).toHaveTextContent(JSON.stringify(mockMenuItems.secondaryMenu));
-    expect(getByTestId('logo-destination')).toHaveTextContent(getConfig().LMS_BASE_URL);
+    expect(screen.getByTestId('header')).toBeInTheDocument();
+    expect(screen.getByTestId('main-menu')).toHaveTextContent(JSON.stringify(mockMenuItems.mainMenu));
+    expect(screen.getByTestId('secondary-menu')).toHaveTextContent(JSON.stringify(mockMenuItems.secondaryMenu));
+    expect(screen.getByTestId('logo-destination')).toHaveTextContent(getConfig().LMS_BASE_URL);
   });
 
   it('should display Help link if SUPPORT_URL is set', () => {
     mergeConfig({ SUPPORT_URL: getConfig().SUPPORT_URL });
-    const { getByTestId } = render(<CatalogHeader />);
-    const secondaryMenuText = getByTestId('secondary-menu').textContent;
+    render(<CatalogHeader />);
+    const secondaryMenuText = screen.getByTestId('secondary-menu').textContent;
     const secondaryMenu = secondaryMenuText ? JSON.parse(secondaryMenuText) : [];
 
     expect(secondaryMenu).toHaveLength(1);
@@ -90,8 +90,8 @@ describe('CatalogHeader', () => {
     };
     (useMenuItems as jest.Mock).mockReturnValue(mockMenuItemsWithPrograms);
 
-    const { getByTestId } = render(<CatalogHeader />);
-    const mainMenuText = getByTestId('main-menu').textContent;
+    render(<CatalogHeader />);
+    const mainMenuText = screen.getByTestId('main-menu').textContent;
     const mainMenu = mainMenuText ? JSON.parse(mainMenuText) : [];
 
     expect(mainMenu).toContainEqual(
@@ -108,8 +108,8 @@ describe('CatalogHeader', () => {
     };
     (useMenuItems as jest.Mock).mockReturnValue(mockMenuItemsWithoutDiscovery);
 
-    const { getByTestId } = render(<CatalogHeader />);
-    const mainMenuText = getByTestId('main-menu').textContent;
+    render(<CatalogHeader />);
+    const mainMenuText = screen.getByTestId('main-menu').textContent;
     const mainMenu = mainMenuText ? JSON.parse(mainMenuText) : [];
 
     expect(mainMenu).not.toContainEqual(
@@ -127,8 +127,8 @@ describe('CatalogHeader', () => {
     };
     (useMenuItems as jest.Mock).mockReturnValue(mockMenuItemsWithoutHelp);
 
-    const { getByTestId } = render(<CatalogHeader />);
-    const secondaryMenuText = getByTestId('secondary-menu').textContent;
+    render(<CatalogHeader />);
+    const secondaryMenuText = screen.getByTestId('secondary-menu').textContent;
     const secondaryMenu = secondaryMenuText ? JSON.parse(secondaryMenuText) : [];
 
     expect(secondaryMenu).toHaveLength(0);
@@ -148,8 +148,8 @@ describe('CatalogHeader', () => {
     };
     (useMenuItems as jest.Mock).mockReturnValue(mockMenuItemsWithActive);
 
-    const { getByTestId } = render(<CatalogHeader />);
-    const mainMenuText = getByTestId('main-menu').textContent;
+    render(<CatalogHeader />);
+    const mainMenuText = screen.getByTestId('main-menu').textContent;
     const mainMenu = mainMenuText ? JSON.parse(mainMenuText) : [];
 
     expect(mainMenu[0].isActive).toBe(true);
@@ -163,9 +163,9 @@ describe('CatalogHeader', () => {
     };
     (useMenuItems as jest.Mock).mockReturnValue(mockEmptyMenuItems);
 
-    const { getByTestId } = render(<CatalogHeader />);
-    const mainMenuText = getByTestId('main-menu').textContent;
-    const secondaryMenuText = getByTestId('secondary-menu').textContent;
+    render(<CatalogHeader />);
+    const mainMenuText = screen.getByTestId('main-menu').textContent;
+    const secondaryMenuText = screen.getByTestId('secondary-menu').textContent;
     const mainMenu = mainMenuText ? JSON.parse(mainMenuText) : [];
     const secondaryMenu = secondaryMenuText ? JSON.parse(secondaryMenuText) : [];
 
@@ -189,8 +189,8 @@ describe('CatalogHeader', () => {
     (useMenuItems as jest.Mock).mockReturnValue(mockMenuItemsWithExploreCourses);
     mergeConfig({ ENABLE_COURSE_DISCOVERY: true });
 
-    const { getByTestId } = render(<CatalogHeader />);
-    const mainMenuText = getByTestId('main-menu').textContent;
+    render(<CatalogHeader />);
+    const mainMenuText = screen.getByTestId('main-menu').textContent;
     const mainMenu = mainMenuText ? JSON.parse(mainMenuText) : [];
 
     expect(mainMenu).toContainEqual(
@@ -232,13 +232,13 @@ describe('CatalogHeader', () => {
     };
     (useMenuItems as jest.Mock).mockReturnValue(mockMenuItemsForAuth);
 
-    const { getByTestId } = render(
+    render(
       <AppContext.Provider value={{ authenticatedUser }}>
         <CatalogHeader />
       </AppContext.Provider>,
     );
 
-    const mainMenuText = getByTestId('main-menu').textContent;
+    const mainMenuText = screen.getByTestId('main-menu').textContent;
     const mainMenu = mainMenuText ? JSON.parse(mainMenuText) : [];
 
     expect(mainMenu).toHaveLength(3);
@@ -268,13 +268,13 @@ describe('CatalogHeader', () => {
     };
     (useMenuItems as jest.Mock).mockReturnValue(mockMenuItemsForNonAuth);
 
-    const { getByTestId } = render(
+    render(
       <AppContext.Provider value={{ authenticatedUser: null }}>
         <CatalogHeader />
       </AppContext.Provider>,
     );
 
-    const mainMenuText = getByTestId('main-menu').textContent;
+    const mainMenuText = screen.getByTestId('main-menu').textContent;
     const mainMenu = mainMenuText ? JSON.parse(mainMenuText) : [];
 
     expect(mainMenu).toHaveLength(1);

--- a/src/header/CatalogHeader.tsx
+++ b/src/header/CatalogHeader.tsx
@@ -1,0 +1,18 @@
+import Header from '@edx/frontend-component-header';
+import { getConfig } from '@edx/frontend-platform';
+
+import { useMenuItems } from './hooks/useMenuItems';
+
+const CatalogHeader = () => {
+  const { mainMenu, secondaryMenu, isNotHomePage } = useMenuItems();
+
+  return (
+    <Header
+      mainMenuItems={mainMenu}
+      logoDestination={!isNotHomePage && getConfig().LMS_BASE_URL}
+      secondaryMenuItems={secondaryMenu}
+    />
+  );
+};
+
+export default CatalogHeader;

--- a/src/header/hooks/useMenuItems.test.tsx
+++ b/src/header/hooks/useMenuItems.test.tsx
@@ -1,0 +1,172 @@
+import { ReactNode, useMemo } from 'react';
+import { useLocation } from 'react-router-dom';
+import { AppContext } from '@edx/frontend-platform/react';
+import { getConfig } from '@edx/frontend-platform';
+import { IntlProvider } from '@edx/frontend-platform/i18n';
+
+import { cleanup, renderHook } from '@src/setupTest';
+
+import { ROUTES } from '@src/routes';
+import messages from '../messages';
+import { useMenuItems } from './useMenuItems';
+
+const DEFAULT_CONFIG = {
+  LMS_BASE_URL: process.env.LMS_BASE_URL,
+  SUPPORT_URL: process.env.SUPPORT_URL,
+  ENABLE_PROGRAMS: true,
+  ENABLE_COURSE_DISCOVERY: true,
+  COURSES_ARE_BROWSABLE: true,
+};
+
+jest.mock('react-router-dom', () => ({
+  useLocation: jest.fn(),
+}));
+
+jest.mock('@edx/frontend-platform', () => ({
+  getConfig: jest.fn(() => DEFAULT_CONFIG),
+  ensureConfig: jest.fn(),
+  mergeConfig: jest.fn(),
+  setConfig: jest.fn(),
+}));
+
+const createWrapper = (authenticatedUser: {
+  username: string } | null) => function Wrapper({ children }: { children: ReactNode }) {
+  const contextValue = useMemo(() => ({ authenticatedUser }), [authenticatedUser]);
+
+  return (
+    <AppContext.Provider value={contextValue}>
+      <IntlProvider locale="en">
+        {children}
+      </IntlProvider>
+    </AppContext.Provider>
+  );
+};
+
+describe('useMenuItems', () => {
+  const mockLocation = {
+    pathname: '/',
+  };
+
+  beforeEach(() => {
+    (useLocation as jest.Mock).mockReturnValue(mockLocation);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+    cleanup();
+  });
+
+  it('should return correct menu items for non-authenticated user', () => {
+    const { result } = renderHook(() => useMenuItems(), { wrapper: createWrapper(null) });
+
+    expect(result.current.mainMenu).toHaveLength(1);
+    expect(result.current.mainMenu[0]).toEqual({
+      type: 'item',
+      href: `${getConfig().LMS_BASE_URL}${ROUTES.COURSES}`,
+      content: messages.exploreCourses.defaultMessage,
+      isActive: false,
+    });
+  });
+
+  it('should return correct menu items for authenticated user', () => {
+    const { result } = renderHook(() => useMenuItems(), { wrapper: createWrapper({ username: 'testuser' }) });
+
+    expect(result.current.mainMenu).toHaveLength(3);
+    expect(result.current.mainMenu[0]).toEqual({
+      type: 'item',
+      href: `${getConfig().LMS_BASE_URL}/dashboard`,
+      content: messages.courses.defaultMessage,
+    });
+    expect(result.current.mainMenu[1]).toEqual({
+      type: 'item',
+      href: expect.stringContaining('/programs'),
+      content: messages.programs.defaultMessage,
+    });
+    expect(result.current.mainMenu[2]).toEqual({
+      type: 'item',
+      href: `${getConfig().LMS_BASE_URL}${ROUTES.COURSES}`,
+      content: messages.discoverNew.defaultMessage,
+      isActive: false,
+    });
+  });
+
+  it('should not include programs menu item when ENABLE_PROGRAMS is false', () => {
+    (getConfig as jest.Mock).mockReturnValue({
+      ...DEFAULT_CONFIG,
+      ENABLE_PROGRAMS: false,
+    });
+
+    const { result } = renderHook(() => useMenuItems(), { wrapper: createWrapper({ username: 'testuser' }) });
+
+    expect(result.current.mainMenu).toHaveLength(2);
+    expect(result.current.mainMenu.some(item => item.content === messages.programs.defaultMessage)).toBe(false);
+  });
+
+  it('should not include course discovery menu item when ENABLE_COURSE_DISCOVERY is false', () => {
+    (getConfig as jest.Mock).mockReturnValue({
+      ...DEFAULT_CONFIG,
+      ENABLE_PROGRAMS: false,
+      ENABLE_COURSE_DISCOVERY: false,
+    });
+
+    const { result } = renderHook(() => useMenuItems(), { wrapper: createWrapper(null) });
+
+    expect(result.current.mainMenu).toHaveLength(0);
+  });
+
+  it('should set isActive to true when on course catalog page', () => {
+    (getConfig as jest.Mock).mockReturnValue(DEFAULT_CONFIG);
+
+    (useLocation as jest.Mock).mockReturnValue({
+      pathname: ROUTES.COURSES,
+    });
+
+    const { result } = renderHook(() => useMenuItems(), { wrapper: createWrapper(null) });
+
+    expect(result.current.mainMenu[0].isActive).toBe(true);
+  });
+
+  it('should include help link in secondary menu when SUPPORT_URL is configured', () => {
+    const { result } = renderHook(() => useMenuItems(), { wrapper: createWrapper(null) });
+
+    expect(result.current.secondaryMenu).toHaveLength(1);
+    expect(result.current.secondaryMenu[0]).toEqual({
+      type: 'item',
+      href: getConfig().SUPPORT_URL,
+      content: messages.help.defaultMessage,
+    });
+  });
+
+  it('should not include help link in secondary menu when SUPPORT_URL is not configured', () => {
+    (getConfig as jest.Mock).mockReturnValue({
+      ...DEFAULT_CONFIG,
+      SUPPORT_URL: undefined,
+      ENABLE_PROGRAMS: false,
+      ENABLE_COURSE_DISCOVERY: false,
+    });
+
+    const { result } = renderHook(() => useMenuItems(), { wrapper: createWrapper(null) });
+
+    expect(result.current.secondaryMenu).toHaveLength(0);
+  });
+
+  it('should set isNotHomePage to true when on course catalog page', () => {
+    (useLocation as jest.Mock).mockReturnValue({
+      pathname: ROUTES.COURSES,
+    });
+
+    const { result } = renderHook(() => useMenuItems(), { wrapper: createWrapper(null) });
+
+    expect(result.current.isNotHomePage).toBe(true);
+  });
+
+  it('should set isNotHomePage to true when on course about page', () => {
+    (useLocation as jest.Mock).mockReturnValue({
+      pathname: `${ROUTES.COURSE_ABOUT}/some-course`,
+    });
+
+    const { result } = renderHook(() => useMenuItems(), { wrapper: createWrapper(null) });
+
+    expect(result.current.isNotHomePage).toBe(true);
+  });
+});

--- a/src/header/hooks/useMenuItems.ts
+++ b/src/header/hooks/useMenuItems.ts
@@ -1,0 +1,65 @@
+import { useContext } from 'react';
+import { useLocation } from 'react-router-dom';
+import { useIntl } from '@edx/frontend-platform/i18n';
+import { AppContext } from '@edx/frontend-platform/react';
+import { getConfig } from '@edx/frontend-platform';
+
+import { ROUTES } from '@src/routes';
+import { programsUrl } from '@src/utils';
+import { useFrontendParams } from '@src/data/frontend-params';
+import { AppContextTypes, MenuItem } from '../types';
+import messages from '../messages';
+
+export const useMenuItems = () => {
+  const intl = useIntl();
+  const location = useLocation();
+  const { authenticatedUser } = useContext(AppContext) as AppContextTypes;
+  // TODO: Waiting for a solution to use this API to save configurations
+  const { data: frontendParams } = useFrontendParams();
+
+  const isCourseCatalogPage = location.pathname === ROUTES.COURSES;
+  const isCourseAboutPage = location.pathname.includes(ROUTES.COURSE_ABOUT);
+  const isNotHomePage = isCourseCatalogPage || isCourseAboutPage;
+
+  const getNotAuthenticatedUserMainMenu = (): MenuItem[] => [
+    ...(frontendParams?.enableCourseDiscovery ? [{
+      type: 'item' as const,
+      href: `${getConfig().LMS_BASE_URL}${ROUTES.COURSES}`,
+      content: intl.formatMessage(messages.exploreCourses),
+      isActive: isCourseCatalogPage,
+    }] : []),
+  ];
+
+  const getAuthenticatedUserMainMenu = (): MenuItem[] => [
+    {
+      type: 'item' as const,
+      href: `${getConfig().LMS_BASE_URL}/dashboard`,
+      content: intl.formatMessage(messages.courses),
+    },
+    ...(getConfig().ENABLE_PROGRAMS ? [{
+      type: 'item' as const,
+      href: `${programsUrl()}`,
+      content: intl.formatMessage(messages.programs),
+    }] : []),
+    ...(!getConfig().NON_BROWSABLE_COURSES ? [{
+      type: 'item' as const,
+      href: `${getConfig().LMS_BASE_URL}${ROUTES.COURSES}`,
+      content: intl.formatMessage(messages.discoverNew),
+      isActive: isCourseCatalogPage,
+    }] : []),
+  ];
+
+  const getSecondaryMenu = (): MenuItem[] => [
+    ...(getConfig().SUPPORT_URL ? [{
+      type: 'item' as const,
+      href: `${getConfig().SUPPORT_URL}`,
+      content: intl.formatMessage(messages.help),
+    }] : []),
+  ];
+
+  return {
+    mainMenu: authenticatedUser ? getAuthenticatedUserMainMenu() : getNotAuthenticatedUserMainMenu(),
+    secondaryMenu: getSecondaryMenu(),
+    isNotHomePage,
+  };
+};

--- a/src/header/messages.ts
+++ b/src/header/messages.ts
@@ -1,0 +1,36 @@
+import { defineMessages } from '@edx/frontend-platform/i18n';
+
+const messages = defineMessages({
+  dashboard: {
+    id: 'category.header.dashboard.label',
+    defaultMessage: 'Dashboard',
+    description: 'The text for the link to the Dashboard page.',
+  },
+  help: {
+    id: 'category.header.help.label',
+    defaultMessage: 'Help',
+    description: 'The text for the link to the Help Center.',
+  },
+  courses: {
+    id: 'category.header.course',
+    defaultMessage: 'Courses',
+    description: 'Header link for switching to Dashboard page.',
+  },
+  exploreCourses: {
+    id: 'category.header.explore-courses',
+    defaultMessage: 'Explore courses',
+    description: 'Header link for switching to Dashboard page.',
+  },
+  programs: {
+    id: 'category.header.programs',
+    defaultMessage: 'Programs',
+    description: 'Header link for switching to Programs page.',
+  },
+  discoverNew: {
+    id: 'category.header.discoverNew',
+    defaultMessage: 'Discover new',
+    description: 'Header link for switching to Course Catalog page.',
+  },
+});
+
+export default messages;

--- a/src/header/types.ts
+++ b/src/header/types.ts
@@ -1,0 +1,24 @@
+interface AuthenticatedUserTypes {
+  email: string;
+  userId: number;
+  username: string;
+  roles: string[];
+  administrator: boolean;
+  name: string;
+}
+
+export interface ConfigTypes {
+  [key: string]: string | boolean | number | Record<string, any>;
+}
+
+export interface AppContextTypes {
+  authenticatedUser: AuthenticatedUserTypes | null;
+  config: ConfigTypes;
+}
+
+export interface MenuItem {
+  type: 'item';
+  href: string;
+  content: string;
+  isActive?: boolean;
+}

--- a/src/index.test.tsx
+++ b/src/index.test.tsx
@@ -26,7 +26,10 @@ describe('Index', () => {
     await import('./index');
 
     expect(initialize).toHaveBeenCalledWith({
-      messages: expect.any(Object),
+      handlers: {
+        config: expect.any(Function),
+      },
+      messages: expect.any(Array),
     });
   });
 });

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -2,11 +2,12 @@ import 'core-js/stable';
 import 'regenerator-runtime/runtime';
 
 import {
-  APP_INIT_ERROR, APP_READY, subscribe, initialize,
+  APP_INIT_ERROR, APP_READY, subscribe, initialize, mergeConfig,
 } from '@edx/frontend-platform';
 import { ErrorPage } from '@edx/frontend-platform/react';
 import { createRoot } from 'react-dom/client';
 
+import { configuration } from './config';
 import App from './App';
 import messages from './i18n';
 
@@ -23,6 +24,13 @@ subscribe(APP_INIT_ERROR, (error: { message: any; }) => {
   root.render(<ErrorPage message={error.message} />);
 });
 
+export const appName = 'CatalogAppConfig';
+
 initialize({
+  handlers: {
+    config: () => {
+      mergeConfig(configuration, appName);
+    },
+  },
   messages,
 });

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,22 @@
+import { getConfig } from '@edx/frontend-platform';
+
+/**
+ * Gets the base URL for the LMS from the frontend platform configuration.
+ */
+export const getBaseUrl = () => getConfig().LMS_BASE_URL;
+
+/**
+ * Resolves a URL by combining it with a base URL if it's relative.
+ * If the URL is null or absolute (starts with http:// or https://), it is returned as is.
+ */
+export const resolveUrl = (base: string, url: string) => ((url == null || url.startsWith('http://') || url.startsWith('https://')) ? url : `${base}${url}`);
+
+/**
+ * Creates a full URL by combining the LMS base URL with a relative path.
+ */
+export const baseAppUrl = (url: string) => resolveUrl(getBaseUrl(), url);
+
+/**
+ * Gets the URL for the programs dashboard page.
+ */
+export const programsUrl = () => baseAppUrl('/dashboard/programs');


### PR DESCRIPTION
> [!NOTE]
> Dependencies:
> - [ ] [BE - feat: [FC-86] implement index page config api](https://github.com/openedx/edx-platform/pull/36842)
> - [ ] [BE - feat: add redirects to mfe for catalog-related legacy pages](https://github.com/openedx/edx-platform/pull/36895)
> - [ ] [BE - feat: [FC-86] update course_about & catalog link generation](https://github.com/openedx/edx-platform/pull/36867)
> - [ ] [FE - feat: [FC-86] Home page banner section](https://github.com/openedx/frontend-app-catalog/pull/7)
> - [ ] [FE - feat: [FC-86] Added Home page courses list](https://github.com/raccoongang/frontend-app-catalog/pull/16)
> - [ ] [FE - feat: [FC-86] Added plugin-slots for Home page](https://github.com/raccoongang/frontend-app-catalog/pull/17)

> [!WARNING]  
> - [ ] Merging all dependencies
> - [ ] Solving the redirect problem
> - [ ] Results of the discussion on frontend config

### Description

This PR extends the [frontend-component-header](https://github.com/openedx/frontend-component-header) settings for the Index, Course Catalog, and Course About pages.

### Useful information

- Related PR: https://github.com/openedx/frontend-component-header/pull/598
- [Figma design](https://www.figma.com/design/wbp0938O3w2pCbrP3U3jDL/MFE---Plug-in-slots-proposal?node-id=0-1&p=f&t=bxIG84LnDDm8kJmQ-0)
- For the MFE Catalog pages we can use a similar approach to [frontend-app-learner-dashboard](https://github.com/openedx/frontend-app-learner-dashboard/blob/master/src/containers/LearnerDashboardHeader/index.jsx#L32) with passing the necessary links directly to the [frontend-component-header](https://github.com/openedx/frontend-component-header) (<Header />)
- Home route - `/catalog/` (only Home page)
- Discover new/Explore courses - link titles that change depending on whether the user is logged in or not
- The link to Programs according to the Legacy template is only visible to authorized users
- `/learner-dashboard` - link for Course about and Catalog pages, if the user is not authorized, a redirection occurs to the authorization page. First of all, the request occurs on the `/dashboard`, if MFE is enabled the user goes to `/learner-dashboard`, if not on the legacy `/dashboard` page (backend redirects).

#### Initial setup

1. Clone and install the tutor-mfe plugin from [the draft PR](https://github.com/overhangio/tutor-mfe/pull/259) that adds support for Catalog MFE.
2. Go to http://apps.local.openedx.io:1998/catalog/

#### How Has This Been Tested?

**The header for unauthenticated users has the following elements:**

- Logo
`/` - link for Home page
`/learner-dashboard` - link for Course about and Catalog pages (and then BE redirect to login page)
- Explore courses link (`/courses`)
- Programs link (`/dashboard/programs`) - if `ENABLE_PROGRAMS=true` in Site Config
- Help link - depend on `SUPPORT_URL` from Site Config
- Sign Up button
- Login button

**The header for authenticated users has the following elements:**

- Logo
`/` - link for Home page (and then BE redirect to learner-dashboard page)
`/learner-dashboard` - link for Course about and Catalog pages
- Courses link (`/learner-dashboard`)
- Programs link (`/dashboard/programs`) - if `ENABLE_PROGRAMS=true` in Site Config
- Discover new link (`/courses`)
- Help link - depend on `SUPPORT_URL` from Site Config