### PR TITLE
feat: [FC-86] Added Course About sidebar

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -13,6 +13,7 @@ module.exports = createConfig(
       'no-restricted-exports': 'off',
       // There is no reason to disallow this syntax anymore; we don't use regenerator-runtime in new browsers
       'no-restricted-syntax': 'off',
+      'prop-types': 'off',
     },
   },
 );

--- a/src/course-about/CourseAboutPage.scss
+++ b/src/course-about/CourseAboutPage.scss
@@ -1,4 +1,5 @@
 @import "course-intro/course-media/CourseMedia";
+@import "course-sidebar/CourseSidebar";
 
 .course-about-intro {
   .pgn__card {

--- a/src/course-about/CourseAboutPage.tsx
+++ b/src/course-about/CourseAboutPage.tsx
@@ -9,6 +9,7 @@ import CourseMedia from './course-intro/course-media/CourseMedia';
 import { CourseIntro } from './course-intro/CourseIntro';
 import { useCourseAboutData } from './data/hooks';
 import { GRID_LAYOUT } from './constants';
+import CourseSidebar from './course-sidebar/CourseSidebar';
 import messages from './messages';
 
 const CourseAboutPage = () => {
@@ -50,6 +51,16 @@ const CourseAboutPage = () => {
           </Layout.Element>
         </Layout>
       </div>
+      <Layout {...GRID_LAYOUT}>
+        <Layout.Element>
+          <h2>About This Course</h2>
+        </Layout.Element>
+        <Layout.Element>
+          <aside>
+            <CourseSidebar courseAboutData={courseAboutData} />
+          </aside>
+        </Layout.Element>
+      </Layout>
     </Container>
   );
 };

--- a/src/course-about/course-sidebar/CourseSidebar.scss
+++ b/src/course-about/course-sidebar/CourseSidebar.scss
@@ -1,0 +1,11 @@
+.course-sidebar {
+  .course-sidebar-course-details {
+    border-top: var(--pgn-size-border-width) solid var(--pgn-color-gray-100);
+    border-bottom: var(--pgn-size-border-width) solid var(--pgn-color-gray-100);
+    padding: var(--pgn-spacing-spacer-base) calc(var(--pgn-spacing-spacer-base) * 1.125);
+  }
+
+  .course-sidebar-course-details-prerequisites {
+    padding: var(--pgn-spacing-spacer-0) calc(var(--pgn-spacing-spacer-base) * 1.125);
+  }
+}

--- a/src/course-about/course-sidebar/CourseSidebar.tsx
+++ b/src/course-about/course-sidebar/CourseSidebar.tsx
@@ -1,0 +1,16 @@
+import { Card } from '@openedx/paragon';
+
+import SidebarSocial from './sidebar-social/SidebarSocial';
+import SidebarDetails from './sidebar-details/SidebarDetails';
+import { CourseAboutData } from '../types';
+
+const CourseSidebar = ({ courseAboutData }: { courseAboutData: CourseAboutData }) => (
+  <Card className="course-sidebar">
+    <Card.Section className="p-0">
+      <SidebarSocial courseAboutData={courseAboutData} />
+      <SidebarDetails courseAboutData={courseAboutData} />
+    </Card.Section>
+  </Card>
+);
+
+export default CourseSidebar;

--- a/src/course-about/course-sidebar/sidebar-details/SidebarDetails.tsx
+++ b/src/course-about/course-sidebar/sidebar-details/SidebarDetails.tsx
@@ -1,0 +1,56 @@
+import { Stack } from '@openedx/paragon';
+import { ListView as ListViewIcon } from '@openedx/paragon/icons';
+import { getConfig } from '@edx/frontend-platform';
+import { useIntl } from '@edx/frontend-platform/i18n';
+
+import { useFrontendParams } from '@src/data/frontend-params';
+import { CourseAboutData } from '../../types';
+import SidebarDetailsItem from './SidebarDetailsItem';
+import { getSidebarDetails } from './utils';
+import messages from './messages';
+
+const SidebarDetails = ({ courseAboutData }: { courseAboutData: CourseAboutData }) => {
+  const intl = useIntl();
+  const { data: frontendParams } = useFrontendParams();
+
+  const renderPrerequisites = () => {
+    if (!courseAboutData.preRequisiteCourses.length) { return null; }
+
+    const prerequisite = courseAboutData.preRequisiteCourses[0];
+    const prerequisiteUrl = `${getConfig().LMS_BASE_URL}/courses/${prerequisite.key}/about`;
+
+    return (
+      <>
+        <SidebarDetailsItem
+          key="prerequisites"
+          icon={ListViewIcon}
+          label={intl.formatMessage(messages.prerequisites)}
+          value={<a href={prerequisiteUrl}>{prerequisite.display}</a>}
+        />
+        <p className="course-sidebar-course-details-prerequisites m-0 mb-3 border-bottom-0 border-top-0">
+          {intl.formatMessage(messages.prerequisitesCompletion, {
+            prerequisite: <a href={prerequisiteUrl}>{prerequisite.display}</a>,
+          })}
+        </p>
+      </>
+    );
+  };
+
+  return (
+    <Stack direction="vertical">
+      {getSidebarDetails(intl, courseAboutData, frontendParams)
+        .filter(detail => detail.show)
+        .map(detail => (
+          <SidebarDetailsItem
+            key={detail.key}
+            icon={detail.icon}
+            label={detail.label}
+            value={detail.value}
+          />
+        ))}
+      {renderPrerequisites()}
+    </Stack>
+  );
+};
+
+export default SidebarDetails;

--- a/src/course-about/course-sidebar/sidebar-details/SidebarDetailsItem.tsx
+++ b/src/course-about/course-sidebar/sidebar-details/SidebarDetailsItem.tsx
@@ -1,0 +1,15 @@
+import { Icon, Stack } from '@openedx/paragon';
+
+import type { SidebarDetailsItemProps } from './types';
+
+const SidebarDetailsItem = ({ icon, label, value }: SidebarDetailsItemProps) => (
+  <Stack className="course-sidebar-course-details justify-content-between border-bottom-0" direction="horizontal">
+    <Stack direction="horizontal" gap={2}>
+      <Icon src={icon} />
+      <span className="course-sidebar-course-details-label">{label}</span>
+    </Stack>
+    <span className="font-weight-bolder course-sidebar-course-details-value">{value}</span>
+  </Stack>
+);
+
+export default SidebarDetailsItem;

--- a/src/course-about/course-sidebar/sidebar-details/constants.ts
+++ b/src/course-about/course-sidebar/sidebar-details/constants.ts
@@ -1,0 +1,8 @@
+export const SIDEBAR_DETAIL_KEYS = {
+  COURSE_NUMBER: 'course-number',
+  START_DATE: 'start-date',
+  END_DATE: 'end-date',
+  EFFORT: 'effort',
+  PRICE: 'price',
+  REQUIREMENTS: 'requirements',
+} as const;

--- a/src/course-about/course-sidebar/sidebar-details/messages.ts
+++ b/src/course-about/course-sidebar/sidebar-details/messages.ts
@@ -1,0 +1,46 @@
+import { defineMessages } from '@edx/frontend-platform/i18n';
+
+const messages = defineMessages({
+  courseNumber: {
+    id: 'catalog.course-about.sidebar-details.course-number',
+    defaultMessage: 'Course number',
+    description: 'Course number label.',
+  },
+  classesStart: {
+    id: 'catalog.course-about.sidebar-details.classes-start',
+    defaultMessage: 'Classes start',
+    description: 'Classes start label.',
+  },
+  classesEnd: {
+    id: 'catalog.course-about.sidebar-details.classes-end',
+    defaultMessage: 'Classes end',
+    description: 'Classes end label.',
+  },
+  estimatedEffort: {
+    id: 'catalog.course-about.sidebar-details.estimated-effort',
+    defaultMessage: 'Estimated effort',
+    description: 'Estimated effort label.',
+  },
+  price: {
+    id: 'catalog.course-about.sidebar-details.price',
+    defaultMessage: 'Price',
+    description: 'Price label.',
+  },
+  requirements: {
+    id: 'catalog.course-about.sidebar-details.requirements',
+    defaultMessage: 'Requirements',
+    description: 'Requirements label.',
+  },
+  prerequisites: {
+    id: 'catalog.course-about.sidebar-details.prerequisites',
+    defaultMessage: 'Prerequisites',
+    description: 'Prerequisites label.',
+  },
+  prerequisitesCompletion: {
+    id: 'catalog.course-about.sidebar-details.prerequisites-completion',
+    defaultMessage: 'You must successfully complete {prerequisite} before you begin this course.',
+    description: 'Text explaining that a prerequisite course must be completed.',
+  },
+});
+
+export default messages;

--- a/src/course-about/course-sidebar/sidebar-details/types.ts
+++ b/src/course-about/course-sidebar/sidebar-details/types.ts
@@ -1,0 +1,7 @@
+import type { ReactNode, ComponentType } from 'react';
+
+export interface SidebarDetailsItemProps {
+  icon: ComponentType<{ className?: string }>;
+  label: string;
+  value: string | ReactNode;
+}

--- a/src/course-about/course-sidebar/sidebar-details/utils.ts
+++ b/src/course-about/course-sidebar/sidebar-details/utils.ts
@@ -1,0 +1,66 @@
+import { IntlShape } from '@edx/frontend-platform/i18n';
+import {
+  AccessTimeFilled as AccessTimeFilledIcon,
+  Event as EventIcon,
+  Info as InfoIcon,
+  MoneyFilled as MoneyFilledIcon,
+} from '@openedx/paragon/icons';
+
+import { formatDate } from '@src/utils';
+import type { FrontendParamsContextType } from '@src/data/frontend-params';
+import { SIDEBAR_DETAIL_KEYS } from './constants';
+import { CourseAboutData } from '../../types';
+import messages from './messages';
+
+/**
+ * Generates an array of sidebar detail objects for course information display.
+ * Each detail object contains metadata about a specific course attribute.
+*/
+export const getSidebarDetails = (
+  intl: IntlShape,
+  courseAboutData: CourseAboutData,
+  frontendParams: FrontendParamsContextType['data'],
+) => [
+  {
+    key: SIDEBAR_DETAIL_KEYS.COURSE_NUMBER,
+    icon: InfoIcon,
+    label: intl.formatMessage(messages.courseNumber),
+    value: courseAboutData.displayNumberWithDefault,
+    show: true,
+  },
+  {
+    key: SIDEBAR_DETAIL_KEYS.START_DATE,
+    icon: EventIcon,
+    label: intl.formatMessage(messages.classesStart),
+    value: formatDate((courseAboutData.advertisedStart || courseAboutData.start) ?? ''),
+    show: !courseAboutData.startDateIsStillDefault,
+  },
+  {
+    key: SIDEBAR_DETAIL_KEYS.END_DATE,
+    icon: EventIcon,
+    label: intl.formatMessage(messages.classesEnd),
+    value: formatDate(courseAboutData.end ?? ''),
+    show: !!courseAboutData.end,
+  },
+  {
+    key: SIDEBAR_DETAIL_KEYS.EFFORT,
+    icon: AccessTimeFilledIcon,
+    label: intl.formatMessage(messages.estimatedEffort),
+    value: courseAboutData.effort,
+    show: !!courseAboutData.effort,
+  },
+  {
+    key: SIDEBAR_DETAIL_KEYS.PRICE,
+    icon: MoneyFilledIcon,
+    label: intl.formatMessage(messages.price),
+    value: courseAboutData.coursePrice,
+    show: !!courseAboutData.coursePrice && frontendParams?.isCosmeticPriceEnabled,
+  },
+  {
+    key: SIDEBAR_DETAIL_KEYS.REQUIREMENTS,
+    icon: InfoIcon,
+    label: intl.formatMessage(messages.requirements),
+    value: courseAboutData.requirements,
+    show: !!courseAboutData?.requirements,
+  },
+];

--- a/src/course-about/course-sidebar/sidebar-social/SidebarSocial.tsx
+++ b/src/course-about/course-sidebar/sidebar-social/SidebarSocial.tsx
@@ -1,0 +1,58 @@
+import { useMemo } from 'react';
+import {
+  Icon, Stack, Hyperlink, Tooltip, OverlayTrigger,
+} from '@openedx/paragon';
+import { useIntl } from '@edx/frontend-platform/i18n';
+
+import { useFrontendParams } from '@src/data/frontend-params';
+import { CourseAboutData } from '../../types';
+import { getSocialLinks } from './utils';
+import messages from './messages';
+
+const SidebarSocial = ({ courseAboutData }: { courseAboutData: CourseAboutData }) => {
+  const intl = useIntl();
+  const { data: frontendParams } = useFrontendParams();
+
+  const socialLinks = useMemo(
+    () => getSocialLinks(intl, frontendParams).map((link) => ({
+      ...link,
+      destination: typeof link.destination === 'function'
+        ? link.destination(courseAboutData)
+        : link.destination,
+    })),
+    [courseAboutData, intl],
+  );
+
+  return (
+    <OverlayTrigger
+      placement="top"
+      overlay={(
+        <Tooltip id="tooltip-top">
+          {intl.formatMessage(messages.socialSharingTooltip)}
+        </Tooltip>
+      )}
+    >
+      <header>
+        <Stack
+          className="course-sidebar-social-icons justify-content-center my-3"
+          direction="horizontal"
+          gap={4}
+          aria-label={intl.formatMessage(messages.socialSharingOptionsAriaLabel)}
+        >
+          {socialLinks.map((link) => (
+            <Hyperlink key={link.id} destination={link.destination}>
+              <Icon
+                className="course-sidebar-social-icon"
+                src={link.icon}
+                screenReaderText={link.screenReaderText}
+                size="lg"
+              />
+            </Hyperlink>
+          ))}
+        </Stack>
+      </header>
+    </OverlayTrigger>
+  );
+};
+
+export default SidebarSocial;

--- a/src/course-about/course-sidebar/sidebar-social/messages.ts
+++ b/src/course-about/course-sidebar/sidebar-social/messages.ts
@@ -1,0 +1,46 @@
+import { defineMessages } from '@edx/frontend-platform/i18n';
+
+const messages = defineMessages({
+  socialSharingOptionsAriaLabel: {
+    id: 'category.course-about.sidebar-social.social-sharing-options-aria-label',
+    defaultMessage: 'Social sharing options',
+    description: 'Aria label for social sharing options.',
+  },
+  socialSharingTooltip: {
+    id: 'category.course-about.sidebar-social.social-sharing-tooltip',
+    defaultMessage: 'Share with friends and family!',
+    description: 'Tooltip for social sharing options.',
+  },
+  socialSharingTwitter: {
+    id: 'category.course-about.sidebar-social.social-sharing-twitter',
+    defaultMessage: 'Tweet that you\'ve enrolled in this course',
+    description: 'Twitter sharing option.',
+  },
+  socialSharingFacebook: {
+    id: 'category.course-about.sidebar-social.social-sharing-facebook',
+    defaultMessage: 'Post a Facebook message to say you\'ve enrolled in this course',
+    description: 'Facebook sharing option.',
+  },
+  socialSharingEmail: {
+    id: 'category.course-about.sidebar-social.social-sharing-email',
+    defaultMessage: 'Email someone to say you\'ve enrolled in this course',
+    description: 'Email sharing option.',
+  },
+  socialSharingEmailSubject: {
+    id: 'category.course-about.sidebar-social.social-sharing-email-subject',
+    defaultMessage: 'Take a course with {siteName} online',
+    description: 'Email subject for social sharing.',
+  },
+  socialSharingEmailBody: {
+    id: 'category.course-about.sidebar-social.social-sharing-email-body',
+    defaultMessage: 'I just enrolled in {courseNumber} {courseName} through {siteName} {url}',
+    description: 'Email body for social sharing.',
+  },
+  socialSharingTwitterText: {
+    id: 'category.course-about.sidebar-social.social-sharing-twitter-text',
+    defaultMessage: 'I just enrolled in {courseNumber} {courseName} through {platformTwitter} {url}',
+    description: 'Twitter text for social sharing.',
+  },
+});
+
+export default messages;

--- a/src/course-about/course-sidebar/sidebar-social/types.ts
+++ b/src/course-about/course-sidebar/sidebar-social/types.ts
@@ -1,0 +1,4 @@
+export interface CourseAboutData {
+  displayNumberWithDefault: string;
+  name: string;
+}

--- a/src/course-about/course-sidebar/sidebar-social/utils.ts
+++ b/src/course-about/course-sidebar/sidebar-social/utils.ts
@@ -1,0 +1,77 @@
+import { getConfig } from '@edx/frontend-platform';
+import { IntlShape } from '@edx/frontend-platform/i18n';
+import {
+  BsFacebook as BsFacebookIcon,
+  BsTwitterX as BsTwitterXIcon,
+  Email as EmailIcon,
+} from '@openedx/paragon/icons';
+
+import type { FrontendParamsContextType } from '@src/data/frontend-params';
+import { CourseAboutData } from '../../types';
+import messages from './messages';
+
+/**
+ * Gets the formatted share text for different social sharing platforms
+ */
+const getShareText = (intl: IntlShape) => ({
+  EMAIL_SUBJECT: intl.formatMessage(messages.socialSharingEmailSubject),
+  EMAIL_BODY: intl.formatMessage(messages.socialSharingEmailBody),
+  TWEET: intl.formatMessage(messages.socialSharingTwitterText),
+});
+
+/**
+ * Generates a Twitter share URL with formatted tweet text
+ */
+export const getTwitterShareUrl = (data: CourseAboutData, frontendParams: FrontendParamsContextType['data'], intl: IntlShape) => {
+  const tweetText = getShareText(intl).TWEET
+    .replace('{courseNumber}', data.displayNumberWithDefault)
+    .replace('{courseName}', data.name)
+    .replace('{platformTwitter}', frontendParams?.courseAboutTwitterAccount)
+    .replace('{url}', window.location.href);
+  return `https://twitter.com/intent/tweet?text=${encodeURIComponent(tweetText)}`;
+};
+
+/**
+ * Generates a mailto URL for sharing course via email
+ */
+export const getEmailShareUrl = (courseData: CourseAboutData, intl: IntlShape) => {
+  const subject = getShareText(intl).EMAIL_SUBJECT.replace('{siteName}', getConfig().SITE_NAME);
+  const body = getShareText(intl).EMAIL_BODY
+    .replace('{courseNumber}', courseData.displayNumberWithDefault)
+    .replace('{courseName}', courseData.name)
+    .replace('{siteName}', getConfig().SITE_NAME)
+    .replace('{url}', window.location.href);
+  return `mailto:?subject=${encodeURIComponent(subject)}&body=${encodeURIComponent(body)}`;
+};
+
+/**
+ * Generates a Facebook share URL for the current page
+ */
+export const getFacebookShareUrl = () => {
+  if (!window.location.href) { return '#'; }
+  return `https://www.facebook.com/sharer/sharer.php?u=${encodeURIComponent(window.location.href)}`;
+};
+
+/**
+ * Returns an array of social sharing link configurations
+ */
+export const getSocialLinks = (intl: IntlShape, frontendParams: FrontendParamsContextType['data']) => [
+  {
+    id: 'twitter',
+    destination: (courseAboutData: CourseAboutData) => getTwitterShareUrl(courseAboutData, frontendParams, intl),
+    icon: BsTwitterXIcon,
+    screenReaderText: intl.formatMessage(messages.socialSharingTwitter),
+  },
+  {
+    id: 'facebook',
+    destination: () => getFacebookShareUrl(),
+    icon: BsFacebookIcon,
+    screenReaderText: intl.formatMessage(messages.socialSharingFacebook),
+  },
+  {
+    id: 'email',
+    destination: (courseData: CourseAboutData) => getEmailShareUrl(courseData, intl),
+    icon: EmailIcon,
+    screenReaderText: intl.formatMessage(messages.socialSharingEmail),
+  },
+];

--- a/src/course-about/types.ts
+++ b/src/course-about/types.ts
@@ -61,7 +61,7 @@ export interface SinglePaidMode {
 
 export interface PrerequisiteCourse {
   key: string;
-  name: string;
+  display: string;
   shortDescription?: string;
 }
 
@@ -128,6 +128,7 @@ export interface CourseAboutData {
   overview: string;
   ocwLinks: OCWLink[];
   prerequisites: string[];
+  requirements: string;
 }
 
 export type CourseAboutDataPartial = Omit<Pick<CourseAboutData,

--- a/src/data/frontend-params/types.ts
+++ b/src/data/frontend-params/types.ts
@@ -1,14 +1,18 @@
 import type { ReactNode } from 'react';
 
 export interface FrontendParamsResponse {
-  homepageOverlayHtml: string | null,
-  showHomepagePromoVideo: boolean,
-  homepagePromoVideoYoutubeId: string,
+  courseAboutShowSocialLinks: boolean,
+  courseAboutTwitterAccount: string,
+  coursesAreBrowsable: boolean,
   enableCourseDiscovery: boolean,
   enableCourseSortingByStartDate: boolean,
-  showPartners: boolean,
   homepageCourseMax: number,
-  coursesAreBrowsable: boolean,
+  homepageOverlayHtml: string | null,
+  homepagePromoVideoYoutubeId: string,
+  isCosmeticPriceEnabled: boolean,
+  showHomepagePromoVideo: boolean,
+  showPartners: boolean,
+  sidebarHtmlEnabled: boolean,
 }
 
 export interface FrontendParamsContextType {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,30 @@
+import { getConfig } from '@edx/frontend-platform';
+
+/**
+ * Gets a cookie by name.
+ */
+export const getCookie = (name: string): string | null => {
+  let cookieValue: string | null = null;
+  if (document.cookie && document.cookie !== '') {
+    const cookies = document.cookie.split(';');
+    for (let i = 0; i < cookies.length; i++) {
+      const cookie = cookies[i].trim();
+      // Does this cookie string begin with the name we want?
+      if (cookie.substring(0, name.length + 1) === `${name}=`) {
+        cookieValue = decodeURIComponent(cookie.substring(name.length + 1));
+        break;
+      }
+    }
+  }
+  return cookieValue;
+};
+
+export const formatDate = (dateString: string): string => {
+  const date = new Date(dateString);
+  const languagePreference = getCookie(getConfig().LANGUAGE_PREFERENCE_COOKIE_NAME);
+  return date.toLocaleDateString(languagePreference || 'en-US', {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+  });
+};


### PR DESCRIPTION
> [!NOTE]
> Dependencies:
> - [ ] [BE - feat: [FC-86] implement index page config api](https://github.com/openedx/edx-platform/pull/36842)
> - [ ] [BE - feat: [FC-86] add sorting feature for engines](https://github.com/openedx/edx-search/pull/205)
> - [ ] [BE - feat: [FC-86] extend courseware api with new fields](https://github.com/openedx/edx-platform/pull/36845)
> - [ ] [FE - feat: [FC-86] Home page banner section](https://github.com/openedx/frontend-app-catalog/pull/7)
> - [ ] [FE - feat: [FC-86] Created Intro section for Course About page](https://github.com/raccoongang/frontend-app-catalog/pull/19)
>
> Dependent PRs:
> - [ ] [feat: [FC-86] Added course overview and updated sidebar](https://github.com/raccoongang/frontend-app-catalog/pull/21)

> [!WARNING]  
> - [ ] Merging all dependencies

### Description

This PR adds a sidebar to the Course About page. Displaying additional fields in the sidebar will be added in the next PR.

### Useful information

[Figma design](https://www.figma.com/design/wbp0938O3w2pCbrP3U3jDL/MFE---Plug-in-slots-proposal?node-id=0-1&p=f&t=bxIG84LnDDm8kJmQ-0)

#### Initial setup

1. Clone and install the tutor-mfe plugin from [the draft PR](https://github.com/overhangio/tutor-mfe/pull/259) that adds support for Catalog MFE.
2. Go to http://apps.local.openedx.io:1998/catalog/

#### How Has This Been Tested?

1. Open `catalog/courses/<course_id>/about` Course About page
2. Ensure the content of the sidebar matches the legacy version
3. Try changing course information, including course image and video, through the Schedule and details page