### PR TITLE
feat: [FC-86] Added course overview and updated sidebar

### DIFF
--- a/src/course-about/CourseAboutPage.scss
+++ b/src/course-about/CourseAboutPage.scss
@@ -40,3 +40,54 @@
     }
   }
 }
+
+.course-about-overview {
+  box-shadow: var(--pgn-elevation-box-shadow-down-1);
+  border-radius: calc(var(--pgn-size-card-border-radius-base) - var(--pgn-size-card-border-width));
+  padding: var(--pgn-spacing-spacer-4);
+
+  .course-about-overview-content {
+    p {
+      margin-bottom: var(--pgn-spacing-spacer-2-5);
+    }
+
+    .course-staff .teacher,
+    .faq .response {
+      margin-bottom: var(--pgn-spacing-spacer-4);
+    }
+
+    .course-staff .teacher .teacher-image {
+      background: var(--pgn-color-white);
+      border: 1px solid var(--pgn-color-gray-200);
+      height: 7.1875rem;
+      width: 7.1875rem;
+      float: left;
+      margin: var(--pgn-spacing-spacer-0) var(--pgn-spacing-spacer-base) var(--pgn-spacing-spacer-0) var(--pgn-spacing-spacer-0);
+      overflow: hidden;
+      padding: 1px;
+    }
+
+    .course-staff .teacher {
+      .teacher-image img {
+        display: block;
+        min-height: 100%;
+        max-width: 100%;
+      }
+
+      &::after {
+        content: "";
+        display: table;
+        clear: both;
+      }
+    }
+
+    .faq .response h3 {
+      font-weight: var(--pgn-typography-font-weight-bold);
+      margin-bottom: var(--pgn-spacing-spacer-base);
+    }
+  }
+}
+
+.course-about-no-course-overview {
+  margin: var(--pgn-spacing-spacer-6) var(--pgn-spacing-spacer-0);
+}

--- a/src/course-about/CourseAboutPage.tsx
+++ b/src/course-about/CourseAboutPage.tsx
@@ -1,8 +1,12 @@
 import { useLocation } from 'react-router';
-import { Container, Layout, Alert } from '@openedx/paragon';
+import { getAuthenticatedUser } from '@edx/frontend-platform/auth';
+import {
+  Container, Layout, Alert, Button, useMediaQuery, breakpoints,
+} from '@openedx/paragon';
 import { ErrorPage } from '@edx/frontend-platform/react';
 import { getConfig } from '@edx/frontend-platform';
 import { useIntl } from '@edx/frontend-platform/i18n';
+import classNames from 'classnames';
 
 import { Loading } from '../generic';
 import CourseMedia from './course-intro/course-media/CourseMedia';
@@ -10,6 +14,7 @@ import { CourseIntro } from './course-intro/CourseIntro';
 import { useCourseAboutData } from './data/hooks';
 import { GRID_LAYOUT } from './constants';
 import CourseSidebar from './course-sidebar/CourseSidebar';
+import { hasVisibleContent, processOverviewContent } from './utils';
 import messages from './messages';
 
 const CourseAboutPage = () => {
@@ -20,6 +25,9 @@ const CourseAboutPage = () => {
     isLoading,
     isError,
   } = useCourseAboutData(courseId);
+  const authenticatedUser = getAuthenticatedUser();
+  const isGlobalStaff = authenticatedUser?.administrator || false;
+  const isExtraSmall = useMediaQuery({ maxWidth: breakpoints.extraSmall.maxWidth });
 
   if (isLoading) {
     return <Loading />;
@@ -39,6 +47,10 @@ const CourseAboutPage = () => {
     );
   }
 
+  const processedOverview = processOverviewContent(courseAboutData.overview, getConfig().LMS_BASE_URL);
+
+  const hasOverviewContent = hasVisibleContent(processedOverview);
+
   return (
     <Container className="container-xl py-5.5" data-testid="course-about-page">
       <div className="course-about-intro-wrapper">
@@ -53,7 +65,31 @@ const CourseAboutPage = () => {
       </div>
       <Layout {...GRID_LAYOUT}>
         <Layout.Element>
-          <h2>About This Course</h2>
+          <Container className="course-about-overview mb-4">
+            {isGlobalStaff && (
+            <Button
+              as="a"
+              size="sm"
+              block={isExtraSmall}
+              variant="outline-primary"
+              href={`${getConfig().STUDIO_BASE_URL}/settings/details/${courseId}`}
+              className={classNames(
+                'float-right',
+                isExtraSmall ? 'mx-0' : 'm-1',
+              )}
+            >
+              {intl.formatMessage(messages.viewAboutPageInStudio)}
+            </Button>
+            )}
+            {hasOverviewContent ? (
+            /* eslint-disable-next-line react/no-danger */
+              <div className="course-about-overview-content" dangerouslySetInnerHTML={{ __html: processedOverview }} />
+            ) : (
+              <div className="course-about-no-course-overview text-center">
+                <p className="m-0">{intl.formatMessage(messages.noCourseOverview)}</p>
+              </div>
+            )}
+          </Container>
         </Layout.Element>
         <Layout.Element>
           <aside>

--- a/src/course-about/constants.ts
+++ b/src/course-about/constants.ts
@@ -1,7 +1,7 @@
 export const GRID_LAYOUT = {
-  lg: [{ span: 12 }, { span: 'auto' }],
-  md: [{ span: 12 }, { span: 'auto' }],
-  sm: [{ span: 12 }, { span: 'auto' }],
-  xs: [{ span: 12 }, { span: 'auto' }],
+  lg: [{ span: 12 }, { span: 12 }],
+  md: [{ span: 12 }, { span: 12 }],
+  sm: [{ span: 12 }, { span: 12 }],
+  xs: [{ span: 12 }, { span: 12 }],
   xl: [{ span: 9 }, { span: 3 }],
 };

--- a/src/course-about/course-sidebar/CourseSidebar.tsx
+++ b/src/course-about/course-sidebar/CourseSidebar.tsx
@@ -1,16 +1,23 @@
 import { Card } from '@openedx/paragon';
 
+import { useFrontendParams } from '@src/data/frontend-params';
 import SidebarSocial from './sidebar-social/SidebarSocial';
 import SidebarDetails from './sidebar-details/SidebarDetails';
 import { CourseAboutData } from '../types';
 
-const CourseSidebar = ({ courseAboutData }: { courseAboutData: CourseAboutData }) => (
-  <Card className="course-sidebar">
-    <Card.Section className="p-0">
-      <SidebarSocial courseAboutData={courseAboutData} />
-      <SidebarDetails courseAboutData={courseAboutData} />
-    </Card.Section>
-  </Card>
-);
+const CourseSidebar = ({ courseAboutData }: { courseAboutData: CourseAboutData }) => {
+  const { data: frontendParams } = useFrontendParams();
+
+  return (
+    <Card className="course-sidebar">
+      <Card.Section className="p-0">
+        {frontendParams?.courseAboutShowSocialLinks && (
+          <SidebarSocial courseAboutData={courseAboutData} />
+        )}
+        <SidebarDetails courseAboutData={courseAboutData} />
+      </Card.Section>
+    </Card>
+  );
+};
 
 export default CourseSidebar;

--- a/src/course-about/course-sidebar/sidebar-details/SidebarDetails.tsx
+++ b/src/course-about/course-sidebar/sidebar-details/SidebarDetails.tsx
@@ -1,5 +1,5 @@
 import { Stack } from '@openedx/paragon';
-import { ListView as ListViewIcon } from '@openedx/paragon/icons';
+import { ListView as ListViewIcon, Link as LinkIcon } from '@openedx/paragon/icons';
 import { getConfig } from '@edx/frontend-platform';
 import { useIntl } from '@edx/frontend-platform/i18n';
 
@@ -13,6 +13,7 @@ const SidebarDetails = ({ courseAboutData }: { courseAboutData: CourseAboutData 
   const intl = useIntl();
   const { data: frontendParams } = useFrontendParams();
 
+  // TODO: clarify about ocw links and prerequisites (https://openedx.slack.com/archives/C08QR8K7K38/p1750850752472279)
   const renderPrerequisites = () => {
     if (!courseAboutData.preRequisiteCourses.length) { return null; }
 
@@ -36,6 +37,43 @@ const SidebarDetails = ({ courseAboutData }: { courseAboutData: CourseAboutData 
     );
   };
 
+  // TODO: clarify about ocw links and prerequisites (https://openedx.slack.com/archives/C08QR8K7K38/p1750850752472279)
+  const renderOcwLinks = () => {
+    // if (!courseAboutData.ocwLinks?.length) { return null; }
+    const ocwLinks = [
+      '<a href="https://ocw.mit.edu/courses/6-006-introduction-to-algorithms-fall-2011/">Introduction to Algorithms</a>',
+      '<a href="https://ocw.mit.edu/courses/6-006-introduction-to-algorithms-fall-2011/">Introduction to Algorithms</a>',
+    ];
+
+    const htmlString = ocwLinks.join('');
+    const parser = new DOMParser();
+    const doc = parser.parseFromString(htmlString, 'text/html');
+    const links = doc.querySelectorAll('a');
+
+    return (
+      <>
+        <SidebarDetailsItem
+          key="ocw-links"
+          icon={LinkIcon}
+          label="Additional Resources"
+        />
+        <div>
+          <span className="px-3 m-0 mb-3 border-bottom-0 border-top-0">
+            {/* "MITOpenCourseware" should *not* be translated */}
+            MITOpenCourseware
+          </span>
+          {Array.from(links).map((link) => (
+            <p key={link.href} className="course-sidebar-course-details-prerequisites m-0 mb-3 border-bottom-0 border-top-0">
+              <a href={link.href} target="_blank" rel="noopener noreferrer">
+                {link.textContent}
+              </a>
+            </p>
+          ))}
+        </div>
+      </>
+    );
+  };
+
   return (
     <Stack direction="vertical">
       {getSidebarDetails(intl, courseAboutData, frontendParams)
@@ -49,6 +87,7 @@ const SidebarDetails = ({ courseAboutData }: { courseAboutData: CourseAboutData 
           />
         ))}
       {renderPrerequisites()}
+      {renderOcwLinks()}
     </Stack>
   );
 };

--- a/src/course-about/course-sidebar/sidebar-details/messages.ts
+++ b/src/course-about/course-sidebar/sidebar-details/messages.ts
@@ -41,6 +41,11 @@ const messages = defineMessages({
     defaultMessage: 'You must successfully complete {prerequisite} before you begin this course.',
     description: 'Text explaining that a prerequisite course must be completed.',
   },
+  ocwLinks: {
+    id: 'catalog.course-about.sidebar-details.ocw-links',
+    defaultMessage: 'Open Courseware links',
+    description: 'Open Courseware links label.',
+  },
 });
 
 export default messages;

--- a/src/course-about/course-sidebar/sidebar-details/types.ts
+++ b/src/course-about/course-sidebar/sidebar-details/types.ts
@@ -3,5 +3,5 @@ import type { ReactNode, ComponentType } from 'react';
 export interface SidebarDetailsItemProps {
   icon: ComponentType<{ className?: string }>;
   label: string;
-  value: string | ReactNode;
+  value?: string | ReactNode;
 }

--- a/src/course-about/messages.ts
+++ b/src/course-about/messages.ts
@@ -6,6 +6,16 @@ const messages = defineMessages({
     defaultMessage: 'If you experience repeated failures, please email support at {supportEmail}',
     description: 'Error page message.',
   },
+  viewAboutPageInStudio: {
+    id: 'catalog.course-about.view-about-page-in-studio',
+    defaultMessage: 'View About Page in Studio',
+    description: 'Link to view the Schedule and Details page in Studio.',
+  },
+  noCourseOverview: {
+    id: 'catalog.course-about.no-course-overview',
+    defaultMessage: 'No course overview added',
+    description: 'Message displayed when no course overview is available.',
+  },
 });
 
 export default messages;

--- a/src/course-about/utils.ts
+++ b/src/course-about/utils.ts
@@ -1,0 +1,41 @@
+import { logInfo } from '@edx/frontend-platform/logging';
+
+/**
+ * Processes overview content to replace image paths
+ * @param overview - The overview HTML content
+ * @returns Processed overview content with updated image paths
+ */
+export const processOverviewContent = (overview: string, lmsBaseUrl: string): string => {
+  if (!overview) { return overview; }
+
+  return overview.replace(
+    /src="\/static\/images\//g,
+    `src="${lmsBaseUrl}/static/images/`,
+  );
+};
+
+/**
+ * Checks if HTML content has real visible content by parsing it through DOM
+ * @param html - The HTML content to check
+ * @returns True if the HTML contains real visible content
+ */
+export const hasVisibleContent = (html: string): boolean => {
+  if (!html) { return false; }
+
+  try {
+    const tempDiv = document.createElement('div');
+    tempDiv.innerHTML = html;
+
+    const technicalElements = tempDiv.querySelectorAll('script, style, meta, link');
+    technicalElements.forEach(el => el.remove());
+
+    const textContent = tempDiv.textContent || tempDiv.innerText || '';
+
+    const cleanText = textContent.trim();
+
+    return cleanText.length > 0;
+  } catch (error) {
+    logInfo('Error parsing HTML content:', error);
+    return false;
+  }
+};


### PR DESCRIPTION
> [!NOTE]
> Dependencies:
> - [ ] [BE - feat: [FC-86] implement index page config api](https://github.com/openedx/edx-platform/pull/36842)
> - [ ] [BE - feat: [FC-86] add sorting feature for engines](https://github.com/openedx/edx-search/pull/205)
> - [ ] [BE - feat: [FC-86] extend courseware api with new fields](https://github.com/openedx/edx-platform/pull/36845)
> - [ ] [FE - feat: [FC-86] Home page banner section](https://github.com/openedx/frontend-app-catalog/pull/7)
> - [ ] [FE - feat: [FC-86] Created Intro section for Course About page](https://github.com/raccoongang/frontend-app-catalog/pull/19)
> - [ ] [FE - feat: [FC-86] Added Course About sidebar](https://github.com/raccoongang/frontend-app-catalog/pull/20)
>
> Dependent PRs:
> - [ ] [FE - feat: [FC-86] Added DataTable for Catalog page](https://github.com/raccoongang/frontend-app-catalog/pull/22)

> [!WARNING]  
> - [ ] Merging all dependencies

### Description

This PR adds an overview block and additional sidebar elements to the Course About page.

### Useful information

[Figma design](https://www.figma.com/design/wbp0938O3w2pCbrP3U3jDL/MFE---Plug-in-slots-proposal?node-id=0-1&p=f&t=bxIG84LnDDm8kJmQ-0)

#### Initial setup

1. Clone and install the tutor-mfe plugin from [the draft PR](https://github.com/overhangio/tutor-mfe/pull/259) that adds support for Catalog MFE.
2. Go to http://apps.local.openedx.io:1998/catalog/

#### How Has This Been Tested?

1. Open `catalog/courses/<course_id>/about` Course About page
2. Ensure the content of the sidebar matches the legacy version
3. Try changing course overview through the Schedule and details page