### PR TITLE
feat: [FC-86] Added DataTable for Catalog page

### DIFF
--- a/src/__mocks__/course.ts
+++ b/src/__mocks__/course.ts
@@ -6,7 +6,7 @@ export const mockCourseResponse = {
     start: '2024-04-01T00:00:00Z',
     imageUrl: '/asset-v1:edX+DemoX+Demo_Course+type@asset+block@course_image.jpg',
     org: 'edX',
-    orgImg: '/asset-v1:edX+DemoX+Demo_Course+type@asset+block@org_image.jpg',
+    orgImageUrl: '/asset-v1:edX+DemoX+Demo_Course+type@asset+block@org_image.jpg',
     content: {
       displayName: 'Demonstration Course',
       overview: 'Course overview',

--- a/src/data/course-discovery/types.ts
+++ b/src/data/course-discovery/types.ts
@@ -3,6 +3,8 @@ export interface CourseDiscoveryResponse {
   total: number;
   results: {
     id: string;
+    index: string;
+    type: string;
     title: string;
     data: {
       id: string;
@@ -10,6 +12,7 @@ export interface CourseDiscoveryResponse {
       start: string;
       imageUrl: string;
       org: string;
+      orgImageUrl?: string;
       content: {
         displayName: string;
         overview?: string;

--- a/src/data/course-discovery/urls.ts
+++ b/src/data/course-discovery/urls.ts
@@ -2,4 +2,4 @@ import { getConfig } from '@edx/frontend-platform';
 
 export const getApiBaseUrl = () => getConfig().LMS_BASE_URL;
 
-export const getCourseDiscoveryUrl = () => `${getApiBaseUrl()}/search/course_discovery/`;
+export const getCourseDiscoveryUrl = () => `${getApiBaseUrl()}/search/v1/course_discovery/`;

--- a/src/generic/course-card/CourseCard.test.tsx
+++ b/src/generic/course-card/CourseCard.test.tsx
@@ -1,14 +1,14 @@
 import { getConfig } from '@edx/frontend-platform';
 
-import { mockCourseResponse } from '../../__mocks__';
-import { render, screen } from '../../setupTest';
+import { mockCourseResponse } from '@src/__mocks__';
+import { render, screen } from '@src/setupTest';
 import { CourseCard } from '.';
 
 import messages from './messages';
 
 describe('CourseCard', () => {
   const renderComponent = (course = mockCourseResponse) => render(
-    <CourseCard course={course} />,
+    <CourseCard original={course} />,
   );
 
   it('renders course information correctly', () => {
@@ -31,7 +31,7 @@ describe('CourseCard', () => {
     renderComponent();
 
     const logo = screen.getByAltText(mockCourseResponse.data.org);
-    expect(logo).toHaveAttribute('src', `${getConfig().LMS_BASE_URL}${mockCourseResponse.data.orgImg}`);
+    expect(logo).toHaveAttribute('src', `${getConfig().LMS_BASE_URL}${mockCourseResponse.data.orgImageUrl}`);
   });
 
   it('formats the link destination correctly', () => {

--- a/src/generic/course-card/index.tsx
+++ b/src/generic/course-card/index.tsx
@@ -12,34 +12,34 @@ import { DATE_FORMAT_OPTIONS } from './constants';
 
 // TODO: Determine the final design for the course Card component.
 // Issue: https://github.com/openedx/frontend-app-catalog/issues/10
-export const CourseCard = ({ course }: CourseCardProps) => {
+export const CourseCard = ({ original: courseData }: CourseCardProps) => {
   const intl = useIntl();
   const isExtraSmall = useMediaQuery({ maxWidth: breakpoints.small.maxWidth });
 
-  const formattedDate = course?.data?.start
-    ? intl.formatDate(new Date(course.data.start), DATE_FORMAT_OPTIONS)
+  const formattedDate = courseData?.data?.start
+    ? intl.formatDate(new Date(courseData.data.start), DATE_FORMAT_OPTIONS)
     : '';
 
   return (
     <Card
       as={Link}
-      to={`/courses/${course.id}/about`}
+      to={`/courses/${courseData.id}/about`}
       className={`course-card ${isExtraSmall ? 'w-100' : 'course-card-desktop'}`}
       isClickable
     >
       <Card.ImageCap
-        src={getFullImageUrl(course.data.imageUrl)}
+        src={getFullImageUrl(courseData.data.imageUrl)}
         fallbackSrc={noCourseImg}
-        srcAlt={`${course.data.content.displayName} ${course.data.number}`}
-        // TODO: Check orgImg field (and add orgImg for course discovery API)
-        logoSrc={course.data.orgImg ? getFullImageUrl(course.data.orgImg) : undefined}
-        fallbackLogoSrc={!course.data.orgImg && noOrgImg}
-        logoAlt={course.data.org}
+        srcAlt={`${courseData.data.content.displayName} ${courseData.data.number}`}
+        // TODO: Check orgImageUrl field (and add orgImageUrl for course discovery API)
+        logoSrc={courseData.data.orgImageUrl ? getFullImageUrl(courseData.data.orgImageUrl) : undefined}
+        fallbackLogoSrc={!courseData.data.orgImageUrl && noOrgImg}
+        logoAlt={courseData.data.org}
       />
       <Card.Section>
-        <h3 className="m-0">{course.data.content.displayName}</h3>
-        <p className="m-0">{course.data.org}</p>
-        <p className="m-0">{course.data.number}</p>
+        <h3 className="m-0">{courseData.data.content.displayName}</h3>
+        <p className="m-0">{courseData.data.org}</p>
+        <p className="m-0">{courseData.data.number}</p>
         {/* TODO: Add advertised_start field */}
         {formattedDate && (
           <span>

--- a/src/generic/course-card/types.ts
+++ b/src/generic/course-card/types.ts
@@ -10,7 +10,7 @@ export interface CourseData {
   start: string;
   imageUrl: string;
   org: string;
-  orgImg?: string;
+  orgImageUrl?: string;
   content: CourseContent;
   number: string;
   modes: string[];
@@ -26,5 +26,5 @@ export interface Course {
 }
 
 export interface CourseCardProps {
-  course: Course;
+  original: Course;
 }

--- a/src/generic/sub-header/index.tsx
+++ b/src/generic/sub-header/index.tsx
@@ -1,7 +1,9 @@
+import classNames from 'classnames';
+
 import { SubHeaderProps } from './types';
 
-export const SubHeader = ({ title }: SubHeaderProps) => (
-  <header className="mb-5 d-flex justify-content-between">
+export const SubHeader = ({ title, className }: SubHeaderProps) => (
+  <header className={classNames('mb-5 d-flex justify-content-between', className)}>
     <h1 className="mb-0">{title}</h1>
   </header>
 );

--- a/src/generic/sub-header/types.ts
+++ b/src/generic/sub-header/types.ts
@@ -1,3 +1,4 @@
 export interface SubHeaderProps {
   title: string;
+  className?: string;
 }

--- a/src/home/components/courses-list/CoursesList.tsx
+++ b/src/home/components/courses-list/CoursesList.tsx
@@ -83,7 +83,7 @@ const CoursesList = () => {
             className="w-100"
           >
             {courseData?.results?.map(course => (
-              <CourseCardSlot key={course.id} course={course} />
+              <CourseCardSlot key={course.id} original={course} />
             ))}
           </CardGrid>
           {courseData?.total > maxCourses && (

--- a/src/index.scss
+++ b/src/index.scss
@@ -5,3 +5,15 @@
 @import "assets/scss/animations";
 @import "home";
 @import "course-about/CourseAboutPage";
+
+.pgn__data-table-layout-sidebar {
+  min-width: 386px;
+}
+
+.pgn__data-table-layout-wrapper {
+  margin-bottom: 20px;
+}
+
+.pgn__searchfield {
+  width: 386px;
+}

--- a/src/plugin-slots/HomeCourseCardSlot/HomeCourseCardSlot.tsx
+++ b/src/plugin-slots/HomeCourseCardSlot/HomeCourseCardSlot.tsx
@@ -3,7 +3,7 @@ import { PluginSlot } from '@openedx/frontend-plugin-framework';
 import { CourseCard } from '@src/generic';
 import { CourseCardProps } from '@src/generic/course-card/types';
 
-const HomeCourseCardSlot = ({ course }: CourseCardProps) => (
+const HomeCourseCardSlot = ({ original: courseData }: CourseCardProps) => (
   <PluginSlot
     id="org.openedx.frontend.catalog.home_page.home_course_card"
     idAliases={['home_course-card']}
@@ -11,7 +11,7 @@ const HomeCourseCardSlot = ({ course }: CourseCardProps) => (
       mergeProps: true,
     }}
   >
-    <CourseCard course={course} />
+    <CourseCard original={courseData} />
   </PluginSlot>
 );
 

--- a/src/сatalog/CatalogPage.tsx
+++ b/src/сatalog/CatalogPage.tsx
@@ -1,17 +1,23 @@
 import {
-  CardGrid, Container, Layout, Alert,
+  Container, Alert, SearchField, DataTable, TextFilter,
+  CardView, CheckboxFilter, useMediaQuery, breakpoints,
 } from '@openedx/paragon';
 import { ErrorPage } from '@edx/frontend-platform/react';
 import { getConfig } from '@edx/frontend-platform';
 import { useIntl } from '@edx/frontend-platform/i18n';
+import classNames from 'classnames';
 
+import { useFrontendParams } from '@src/data/frontend-params/FrontendParamsContext';
 import {
-  AlertNotification, CourseCard, Loading, SubHeader,
+  AlertNotification,
+  CourseCard,
+  Loading,
+  SubHeader,
 } from '../generic';
 import { useCourseDiscovery } from '../data/course-discovery/hooks';
+import { DEFAULT_PAGE_INDEX, DEFAULT_PAGE_SIZE } from '../data/course-discovery/constants';
+import { transformResultsForTable } from './utils';
 import messages from './messages';
-
-const GRID_LAYOUT = { xl: [{ span: 9 }, { span: 3 }] };
 
 const CatalogPage = () => {
   const intl = useIntl();
@@ -20,6 +26,8 @@ const CatalogPage = () => {
     isLoading,
     isError,
   } = useCourseDiscovery();
+  const { data: frontendParams } = useFrontendParams();
+  const isMedium = useMediaQuery({ maxWidth: breakpoints.large.maxWidth });
 
   if (isLoading) {
     return (
@@ -45,39 +53,69 @@ const CatalogPage = () => {
 
   return (
     <Container className="container-xl pt-5.5">
-      <SubHeader title={intl.formatMessage(messages.totalCoursesHeading, {
-        totalCourses,
-      })}
+      <SubHeader
+        title={intl.formatMessage(messages.exploreCourses)}
+        className={classNames({ 'mx-2.5': isMedium })}
       />
-      <Layout {...GRID_LAYOUT}>
-        <Layout.Element>
-          {totalCourses === 0 ? (
-            <AlertNotification
-              title={intl.formatMessage(messages.noCoursesAvailable)}
-              message={intl.formatMessage(messages.noCoursesAvailableMessage)}
-            />
-          ) : (
-            <CardGrid
-              hasEqualColumnHeights
-              className="mb-6"
-            >
-              {courseData?.results?.map(course => (
-                <CourseCard
-                  key={course.id}
-                  course={course}
-                />
-              ))}
-            </CardGrid>
-          )}
-        </Layout.Element>
-        <Layout.Element>
-          {totalCourses > 0 && (
-          <aside className="sidebar-wrapper">
-            {/* TODO: Implement sidebar functionality with filters and additional course information */}
-          </aside>
-          )}
-        </Layout.Element>
-      </Layout>
+      {totalCourses > 0 ? (
+        <>
+          <SearchField
+            key=""
+            className={classNames({
+              'w-auto mx-2.5 mb-0': isMedium,
+              'mb-4': !isMedium,
+            })}
+            value=""
+            onSubmit={() => {}}
+            onClear={() => {}}
+            placeholder={intl.formatMessage(messages.searchPlaceholder)}
+          />
+          <DataTable
+            isLoading={isLoading}
+            showFiltersInSidebar={!isMedium}
+            isFilterable={frontendParams?.enableCourseDiscovery}
+            isSortable
+            isPaginated
+            defaultColumnValues={{ Filter: TextFilter }}
+            itemCount={totalCourses}
+            initialState={{ pageSize: DEFAULT_PAGE_SIZE, pageIndex: DEFAULT_PAGE_INDEX }}
+            data={transformResultsForTable(courseData?.results)}
+            columns={[
+              {
+                Header: 'Language',
+                accessor: 'language',
+                Filter: CheckboxFilter,
+                filter: 'includesValue',
+                filterChoices: [{
+                  name: 'English',
+                  number: 2,
+                  value: 'English',
+                },
+                {
+                  name: 'Ukrainian',
+                  number: 2,
+                  value: 'Ukrainian',
+                },
+                {
+                  name: 'Spanish',
+                  number: 1,
+                  value: 'Spanish',
+                }],
+              },
+            ]}
+          >
+            <DataTable.TableControlBar />
+            <CardView CardComponent={CourseCard} />
+            <DataTable.EmptyTable content={intl.formatMessage(messages.noResultsFound)} />
+            <DataTable.TableFooter />
+          </DataTable>
+        </>
+      ) : (
+        <AlertNotification
+          title={intl.formatMessage(messages.noCoursesAvailable)}
+          message={intl.formatMessage(messages.noCoursesAvailableMessage)}
+        />
+      )}
     </Container>
   );
 };

--- a/src/сatalog/messages.ts
+++ b/src/сatalog/messages.ts
@@ -21,6 +21,21 @@ const messages = defineMessages({
     defaultMessage: 'Viewing {totalCourses} courses',
     description: 'Total courses heading.',
   },
+  searchPlaceholder: {
+    id: 'category.catalog.search-placeholder',
+    defaultMessage: 'Search for a course',
+    description: 'Search placeholder.',
+  },
+  exploreCourses: {
+    id: 'category.catalog.explore-courses',
+    defaultMessage: 'Explore courses',
+    description: 'Explore courses.',
+  },
+  noResultsFound: {
+    id: 'category.catalog.no-results-found',
+    defaultMessage: 'No results found',
+    description: 'No results found.',
+  },
 });
 
 export default messages;

--- a/src/сatalog/types.ts
+++ b/src/сatalog/types.ts
@@ -1,0 +1,12 @@
+import { CourseDiscoveryResponse } from '../data/course-discovery/types';
+
+export interface TransformedCourseItem {
+  id: string;
+  famous_for: string;
+  language: string;
+  modes: string[];
+  org: string;
+  data: CourseDiscoveryResponse['results'][0]['data'];
+  index?: string;
+  type?: string;
+}

--- a/src/сatalog/utils.ts
+++ b/src/сatalog/utils.ts
@@ -1,0 +1,22 @@
+import type { CourseDiscoveryResponse } from '../data/course-discovery/types';
+import type { TransformedCourseItem } from './types';
+
+/**
+ * Transforms course discovery results into a format suitable for DataTable display.
+ */
+export const transformResultsForTable = (results: CourseDiscoveryResponse['results'] | undefined): TransformedCourseItem[] => {
+  if (!results?.length) {
+    return [];
+  }
+
+  return results.map(item => ({
+    id: item.id,
+    famous_for: item.data.content.displayName,
+    language: item.data.language,
+    modes: item.data.modes,
+    org: item.data.org,
+    data: item.data,
+    index: item.index,
+    type: item.type,
+  }));
+};


### PR DESCRIPTION
> [!NOTE]
> Dependencies:
> - [ ] [BE - feat: [FC-86] implement index page config api](https://github.com/openedx/edx-platform/pull/36842)
> - [ ] [BE - feat: [FC-86] add sorting feature for engines](https://github.com/openedx/edx-search/pull/205)
> - [ ] [BE - feat: [FC-86] extend courseware api with new fields](https://github.com/openedx/edx-platform/pull/36845)
> - [ ] [BE - feat: [FC-86] add org_image_url to course_discovery index FC-86](https://github.com/openedx/edx-platform/pull/36846)
> - [ ] [BE - feat: [FC-86] Add Sorting Feature for Engines](https://github.com/openedx/edx-search/pull/205)
> - [ ] [BE - feat: [FC-86] create new version of course discovery API](https://github.com/raccoongang/edx-search/pull/13)
> - [ ] [BE - feat: [FC-86] implement multivalue faceted search using Meilisearch and Elasticsearch](https://github.com/openedx/edx-search/pull/213)
> - [ ] [FE - feat: [FC-86] Home page banner section](https://github.com/openedx/frontend-app-catalog/pull/7)
> - [ ] [FE - feat: [FC-86] Added Home page courses list](https://github.com/raccoongang/frontend-app-catalog/pull/16)
> - [ ] [FE - feat: [FC-86] Added plugin-slots for Home page](https://github.com/raccoongang/frontend-app-catalog/pull/17)
> - [ ] [FE - feat: [FC-86] Created Intro section for Course About page](https://github.com/raccoongang/frontend-app-catalog/pull/19)
> - [ ] [FE - feat: [FC-86] Added Course About sidebar](https://github.com/raccoongang/frontend-app-catalog/pull/20)
> - [ ] [feat: [FC-86] Added course overview and updated sidebar](https://github.com/raccoongang/frontend-app-catalog/pull/21)
>
> Dependent PRs:
> - [ ] [FE - feat: [FC-86] Added filtration for Catalog page](https://github.com/raccoongang/frontend-app-catalog/pull/23)

> [!WARNING]  
> - [ ] Merging all dependencies
> - [ ] Resolve problems with `orgImageUrl`

### Description

A Paragon [DataTable](https://paragon-openedx-v23.netlify.app/components/datatable/) component has been added to the course Catalog page to display course cards. Also added a Paragon [Form.Control](https://paragon-openedx-v23.netlify.app/components/form/form-control/) component that will be used for searching on this page.

### Useful information

[Figma design](https://www.figma.com/design/wbp0938O3w2pCbrP3U3jDL/MFE---Plug-in-slots-proposal?node-id=0-1&p=f&t=bxIG84LnDDm8kJmQ-0)

#### Initial setup

1. Clone and install the tutor-mfe plugin from [the draft PR](https://github.com/overhangio/tutor-mfe/pull/259) that adds support for Catalog MFE.
2. Go to http://apps.local.openedx.io:1998/catalog/courses

#### How Has This Been Tested?

1. Go to Course Catalog page (`http://apps.local.openedx.io:1998/catalog/courses`).
2. When loading the page, a loader (spinner) is displayed.
3. If there are no courses, an alert is displayed with information about this.
4. Course cards are displayed inside the DataTable component (logic related to filtering courses will be provided later).
5. The Form.Control component is displayed correctly (search logic will be added later)
6. The page is displayed incorrectly on mobile screens.
7. If an error occurred while loading the page content - an error message is displayed (message taken from [LearnerDashboard MFE](https://github.com/openedx/frontend-app-learner-dashboard/blob/master/src/App.jsx#L87)).

![image](https://github.com/user-attachments/assets/d01acd79-f5f6-413c-ae84-8221358f7b6b)

8. Create a new course from Studio.
9. Check the display of the course card on the new Course Catalog page.
10. If there is no course image, the default image is displayed.

![image](https://github.com/user-attachments/assets/b5900fd7-20de-45aa-8d61-306a1333b784)

11. Through the Schedule and Details page, load the course image and check on the Course Catalog page that the image is displayed.
12. By clicking on the course card, the New Course About page opens (`http://apps.local.openedx.io:1998/catalog/courses/<course_id>/about`) without full page reloading (React Router).