### PR TITLE
feat: [FC-86] Added filtration for Catalog page

### DIFF
--- a/src/data/course-discovery/__tests__/courseDiscovery.test.tsx
+++ b/src/data/course-discovery/__tests__/courseDiscovery.test.tsx
@@ -22,7 +22,7 @@ describe('Course Discovery Data Layer', () => {
       const mockPost = jest.fn().mockResolvedValue({ data: mockCourseDiscoveryResponse });
       mockGetAuthenticatedHttpClient.mockReturnValue({ post: mockPost });
 
-      const result = await fetchCourseDiscovery();
+      const result = await fetchCourseDiscovery({});
 
       expect(mockPost).toHaveBeenCalledTimes(1);
       const [url] = mockPost.mock.calls[0];
@@ -38,7 +38,11 @@ describe('Course Discovery Data Layer', () => {
       const customPageSize = 21;
       const customPageIndex = 2;
 
-      await fetchCourseDiscovery(customPageSize, customPageIndex, true);
+      await fetchCourseDiscovery({
+        pageSize: customPageSize,
+        pageIndex: customPageIndex,
+        enableCourseSortingByStartDate: true,
+      });
 
       const [url, formData] = mockPost.mock.calls[0];
 
@@ -54,7 +58,7 @@ describe('Course Discovery Data Layer', () => {
       const mockPost = jest.fn().mockRejectedValue(error);
       mockGetAuthenticatedHttpClient.mockReturnValue({ post: mockPost });
 
-      await expect(fetchCourseDiscovery()).rejects.toThrow('API Error');
+      await expect(fetchCourseDiscovery({})).rejects.toThrow('API Error');
     });
   });
 

--- a/src/data/course-discovery/api.ts
+++ b/src/data/course-discovery/api.ts
@@ -3,25 +3,40 @@ import { getAuthenticatedHttpClient } from '@edx/frontend-platform/auth';
 
 import { DEFAULT_PAGE_SIZE, DEFAULT_PAGE_INDEX } from './constants';
 import { getCourseDiscoveryUrl } from './urls';
+import { addFiltersToFormData } from './utils';
 
-import { CourseDiscoveryResponse } from './types';
+import { CourseDiscoveryResponse, CourseDiscoveryParams } from './types';
 
 /**
  * Fetches course discovery data from the API.
  * @async
  */
 export const fetchCourseDiscovery = async (
-  pageSize = DEFAULT_PAGE_SIZE,
-  pageIndex = DEFAULT_PAGE_INDEX,
-  enableCourseSortingByStartDate = false,
+  params: CourseDiscoveryParams,
 ): Promise<CourseDiscoveryResponse> => {
+  const {
+    pageSize = DEFAULT_PAGE_SIZE,
+    pageIndex = DEFAULT_PAGE_INDEX,
+    enableCourseSortingByStartDate = false,
+    filters = {},
+  } = params;
+
   const formData = new FormData();
   formData.append('page_size', String(pageSize));
   formData.append('page_index', String(pageIndex));
   formData.append('enable_course_sorting_by_start_date', String(enableCourseSortingByStartDate));
 
-  const { data } = await getAuthenticatedHttpClient()
-    .post(getCourseDiscoveryUrl(), formData);
+  addFiltersToFormData(formData, filters);
+
+  const { data } = await getAuthenticatedHttpClient().post(
+    getCourseDiscoveryUrl(),
+    formData,
+    // {
+    //   headers: {
+    //     'Content-Type': 'multipart/form-data',
+    //   },
+    // },
+  );
 
   return camelCaseObject(data);
 };

--- a/src/data/course-discovery/api.ts
+++ b/src/data/course-discovery/api.ts
@@ -31,11 +31,6 @@ export const fetchCourseDiscovery = async (
   const { data } = await getAuthenticatedHttpClient().post(
     getCourseDiscoveryUrl(),
     formData,
-    // {
-    //   headers: {
-    //     'Content-Type': 'multipart/form-data',
-    //   },
-    // },
   );
 
   return camelCaseObject(data);

--- a/src/data/course-discovery/hooks.ts
+++ b/src/data/course-discovery/hooks.ts
@@ -1,25 +1,96 @@
 import { useQuery } from '@tanstack/react-query';
 
+import { useState, useCallback, useRef } from 'react';
 import { fetchCourseDiscovery } from './api';
 import { DEFAULT_PAGE_SIZE, DEFAULT_PAGE_INDEX } from './constants';
-import { CourseDiscoveryResponse } from './types';
+import {
+  CourseDiscoveryResponse, CourseDiscoveryParams, CourseDiscoveryHook,
+} from './types';
+import { createFetchData } from './utils';
 
-/**
- * A React Query hook that fetches course discovery data.
- */
 export const useCourseDiscovery = ({
-  pageSize,
-  pageIndex,
-  enableCourseSortingByStartDate,
-} = {
-  pageSize: DEFAULT_PAGE_SIZE,
-  pageIndex: DEFAULT_PAGE_INDEX,
-  enableCourseSortingByStartDate: false,
-}) => useQuery<CourseDiscoveryResponse, Error>({
-  queryKey: ['courseDiscovery'],
-  queryFn: () => fetchCourseDiscovery(
+  pageSize = DEFAULT_PAGE_SIZE,
+  pageIndex = DEFAULT_PAGE_INDEX,
+  enableCourseSortingByStartDate = false,
+  filters = {},
+}: Partial<CourseDiscoveryParams> = {}): CourseDiscoveryHook => {
+  const [params, setParams] = useState<CourseDiscoveryParams>({
     pageSize,
     pageIndex,
     enableCourseSortingByStartDate,
-  ),
-});
+    filters,
+  });
+
+  const paramsRef = useRef(params);
+  paramsRef.current = params;
+
+  const {
+    data, isLoading, isError, error, isFetching,
+  } = useQuery<CourseDiscoveryResponse, Error>({
+    queryKey: ['courseDiscovery', params],
+    queryFn: () => fetchCourseDiscovery(params),
+    placeholderData: (previousData) => previousData,
+  });
+
+  /**
+   * Updates query params and triggers data refetch if params have changed.
+   */
+  const fetchData = useCallback(createFetchData(setParams, paramsRef), []);
+
+  return {
+    data,
+    isLoading,
+    isError,
+    error,
+    fetchData,
+    isFetching,
+  };
+};
+
+/**
+ * Custom hook for fetching and managing course discovery data.
+ * Handles backend filtering, pagination, and sorting.
+ */
+// export const useCourseDiscovery = ({
+//   pageSize,
+//   pageIndex,
+//   enableCourseSortingByStartDate,
+//   filters,
+// } = {
+//   pageSize: DEFAULT_PAGE_SIZE,
+//   pageIndex: DEFAULT_PAGE_INDEX,
+//   enableCourseSortingByStartDate: false,
+//   filters: {},
+// }): CourseDiscoveryHook => {
+//   const [params, setParams] = useState<CourseDiscoveryParams>({
+//     pageSize,
+//     pageIndex,
+//     enableCourseSortingByStartDate,
+//     filters,
+//   });
+
+//   const paramsRef = useRef(params);
+//   paramsRef.current = params;
+
+//   const {
+//     data, isLoading, isError, error, isFetching,
+//   } = useQuery<CourseDiscoveryResponse, Error>({
+//     queryKey: ['courseDiscovery', params],
+//     queryFn: () => fetchCourseDiscovery(params),
+//     placeholderData: (previousData) => previousData,
+//   });
+
+//   /**
+//    * Updates query params and triggers data refetch if params have changed.
+//    */
+//   const fetchData = useCallback(createFetchData(setParams, paramsRef), []);
+
+//   return {
+//     data,
+//     isLoading,
+//     isError,
+//     error,
+//     fetchData,
+//     isFetching,
+//   };
+// };

--- a/src/data/course-discovery/hooks.ts
+++ b/src/data/course-discovery/hooks.ts
@@ -1,12 +1,12 @@
 import { useQuery } from '@tanstack/react-query';
 
-import { useState, useCallback, useRef } from 'react';
+import { useState, useCallback } from 'react';
 import { fetchCourseDiscovery } from './api';
 import { DEFAULT_PAGE_SIZE, DEFAULT_PAGE_INDEX } from './constants';
 import {
-  CourseDiscoveryResponse, CourseDiscoveryParams, CourseDiscoveryHook,
+  CourseDiscoveryResponse, CourseDiscoveryParams, CourseDiscoveryHook, DataTableParams,
 } from './types';
-import { createFetchData } from './utils';
+import { transformDataTableFilters } from './utils';
 
 export const useCourseDiscovery = ({
   pageSize = DEFAULT_PAGE_SIZE,
@@ -21,9 +21,6 @@ export const useCourseDiscovery = ({
     filters,
   });
 
-  const paramsRef = useRef(params);
-  paramsRef.current = params;
-
   const {
     data, isLoading, isError, error, isFetching,
   } = useQuery<CourseDiscoveryResponse, Error>({
@@ -35,7 +32,20 @@ export const useCourseDiscovery = ({
   /**
    * Updates query params and triggers data refetch if params have changed.
    */
-  const fetchData = useCallback(createFetchData(setParams, paramsRef), []);
+  const fetchData = useCallback((newParams: DataTableParams) => {
+    const transformedFilters = transformDataTableFilters(newParams.filters);
+
+    const transformedParams: CourseDiscoveryParams = {
+      pageSize: newParams.pageSize,
+      pageIndex: newParams.pageIndex,
+      filters: transformedFilters,
+    };
+
+    setParams(prevParams => {
+      const hasChanged = JSON.stringify(prevParams) !== JSON.stringify(transformedParams);
+      return hasChanged ? transformedParams : prevParams;
+    });
+  }, []);
 
   return {
     data,
@@ -46,51 +56,3 @@ export const useCourseDiscovery = ({
     isFetching,
   };
 };
-
-/**
- * Custom hook for fetching and managing course discovery data.
- * Handles backend filtering, pagination, and sorting.
- */
-// export const useCourseDiscovery = ({
-//   pageSize,
-//   pageIndex,
-//   enableCourseSortingByStartDate,
-//   filters,
-// } = {
-//   pageSize: DEFAULT_PAGE_SIZE,
-//   pageIndex: DEFAULT_PAGE_INDEX,
-//   enableCourseSortingByStartDate: false,
-//   filters: {},
-// }): CourseDiscoveryHook => {
-//   const [params, setParams] = useState<CourseDiscoveryParams>({
-//     pageSize,
-//     pageIndex,
-//     enableCourseSortingByStartDate,
-//     filters,
-//   });
-
-//   const paramsRef = useRef(params);
-//   paramsRef.current = params;
-
-//   const {
-//     data, isLoading, isError, error, isFetching,
-//   } = useQuery<CourseDiscoveryResponse, Error>({
-//     queryKey: ['courseDiscovery', params],
-//     queryFn: () => fetchCourseDiscovery(params),
-//     placeholderData: (previousData) => previousData,
-//   });
-
-//   /**
-//    * Updates query params and triggers data refetch if params have changed.
-//    */
-//   const fetchData = useCallback(createFetchData(setParams, paramsRef), []);
-
-//   return {
-//     data,
-//     isLoading,
-//     isError,
-//     error,
-//     fetchData,
-//     isFetching,
-//   };
-// };

--- a/src/data/course-discovery/types.ts
+++ b/src/data/course-discovery/types.ts
@@ -1,5 +1,5 @@
 export interface CourseDiscoveryResponse {
-  count: number;
+  took: number;
   total: number;
   results: {
     id: string;
@@ -24,4 +24,52 @@ export interface CourseDiscoveryResponse {
       catalogVisibility: string;
     };
   }[];
+  aggs: {
+    [key: string]: {
+      terms: {
+        [key: string]: number;
+      };
+      total: number;
+      other: number;
+    };
+  };
+  maxScore: number;
+}
+
+export interface Aggregations {
+  [key: string]: {
+    terms: {
+      [key: string]: number;
+    };
+  };
+}
+
+export interface CourseDiscoveryParams {
+  pageSize?: number;
+  pageIndex?: number;
+  filters?: Record<string, string[]>;
+  enableCourseSortingByStartDate?: boolean;
+}
+
+export interface DataTableParams {
+  pageSize?: number;
+  pageIndex?: number;
+  filters?: Array<{
+    id: string;
+    value: string | string[];
+  }>;
+}
+
+export interface CourseDiscoveryHook {
+  data: CourseDiscoveryResponse | undefined;
+  isLoading: boolean;
+  isFetching: boolean;
+  isError: boolean;
+  error: Error | null;
+  fetchData: (params: DataTableParams) => void;
+}
+
+export interface DataTableFilter {
+  id: string;
+  value: string | string[];
 }

--- a/src/data/course-discovery/utils.ts
+++ b/src/data/course-discovery/utils.ts
@@ -1,0 +1,85 @@
+import { DataTableFilter, type CourseDiscoveryParams, type DataTableParams } from './types';
+
+/**
+ * Appends filters to the FormData object for backend requests.
+ *
+ * @param {FormData} formData - The FormData object to which filters will be appended.
+ * @param {Record<string, string[]>} filters - An object where the key
+ * is the filter name and the value is an array of filter values.
+ */
+export const addFiltersToFormData = (formData: FormData, filters: Record<string, string[]>) => {
+  if (!filters || typeof filters !== 'object') {
+    return;
+  }
+
+  Object.entries(filters).forEach(([key, values]) => {
+    if (Array.isArray(values)) {
+      values.forEach(value => {
+        if (value !== undefined && value !== null && value !== '') {
+          formData.append(key, value);
+        }
+      });
+    } else if (values !== undefined && values !== null && values !== '') {
+      formData.append(key, values);
+    }
+  });
+};
+
+/**
+ * Transforms DataTable filters array into a Record<string, string[]> for API.
+ */
+export const transformDataTableFilters = (
+  filters?: Array<DataTableFilter>,
+): Record<string, string[]> => {
+  const transformedFilters: Record<string, string[]> = {};
+  if (!filters) {
+    return transformedFilters;
+  }
+
+  const groupedFilters: Record<string, Set<string>> = {};
+
+  filters.forEach((filter) => {
+    if (!groupedFilters[filter.id]) {
+      groupedFilters[filter.id] = new Set();
+    }
+    if (Array.isArray(filter.value)) {
+      filter.value.forEach(value => {
+        if (value !== undefined && value !== null && value !== '') {
+          groupedFilters[filter.id].add(value);
+        }
+      });
+    } else if (filter.value !== undefined && filter.value !== null && filter.value !== '') {
+      groupedFilters[filter.id].add(filter.value);
+    }
+  });
+
+  Object.entries(groupedFilters).forEach(([key, valuesSet]) => {
+    transformedFilters[key] = Array.from(valuesSet);
+  });
+
+  return transformedFilters;
+};
+
+/**
+ * Creates a function that fetches data from the API.
+ */
+export const createFetchData = (
+  setParams: (params: CourseDiscoveryParams) => void,
+  paramsRef: { current: CourseDiscoveryParams },
+) => (newParams: DataTableParams) => {
+  const transformedFilters = transformDataTableFilters(newParams.filters);
+
+  const transformedParams: CourseDiscoveryParams = {
+    pageSize: newParams.pageSize,
+    // pageIndex: newParams.pageIndex,
+    pageIndex: Object.keys(transformedFilters).length > 0 ? 0 : newParams.pageIndex,
+    filters: transformedFilters,
+  };
+
+  const currentParams = paramsRef.current;
+  const hasChanged = JSON.stringify(currentParams) !== JSON.stringify(transformedParams);
+
+  if (hasChanged) {
+    setParams(transformedParams);
+  }
+};

--- a/src/data/course-discovery/utils.ts
+++ b/src/data/course-discovery/utils.ts
@@ -1,4 +1,4 @@
-import { DataTableFilter, type CourseDiscoveryParams, type DataTableParams } from './types';
+import { DataTableFilter } from './types';
 
 /**
  * Appends filters to the FormData object for backend requests.
@@ -58,28 +58,4 @@ export const transformDataTableFilters = (
   });
 
   return transformedFilters;
-};
-
-/**
- * Creates a function that fetches data from the API.
- */
-export const createFetchData = (
-  setParams: (params: CourseDiscoveryParams) => void,
-  paramsRef: { current: CourseDiscoveryParams },
-) => (newParams: DataTableParams) => {
-  const transformedFilters = transformDataTableFilters(newParams.filters);
-
-  const transformedParams: CourseDiscoveryParams = {
-    pageSize: newParams.pageSize,
-    // pageIndex: newParams.pageIndex,
-    pageIndex: Object.keys(transformedFilters).length > 0 ? 0 : newParams.pageIndex,
-    filters: transformedFilters,
-  };
-
-  const currentParams = paramsRef.current;
-  const hasChanged = JSON.stringify(currentParams) !== JSON.stringify(transformedParams);
-
-  if (hasChanged) {
-    setParams(transformedParams);
-  }
 };

--- a/src/сatalog/CatalogPage.tsx
+++ b/src/сatalog/CatalogPage.tsx
@@ -1,6 +1,4 @@
-import {
-  useState, useEffect, useCallback, useMemo,
-} from 'react';
+import { useEffect, useMemo } from 'react';
 import {
   Container, Alert, SearchField, DataTable, TextFilter,
   CardView, useMediaQuery, breakpoints,
@@ -10,16 +8,17 @@ import { getConfig } from '@edx/frontend-platform';
 import { useIntl } from '@edx/frontend-platform/i18n';
 import classNames from 'classnames';
 
-import { useFrontendParams } from '@src/data/frontend-params/FrontendParamsContext';
+import { useFrontendParams } from '../data/frontend-params/FrontendParamsContext';
+import { useCourseDiscovery } from '../data/course-discovery/hooks';
+import { DEFAULT_PAGE_INDEX, DEFAULT_PAGE_SIZE } from '../data/course-discovery/constants';
 import {
   AlertNotification,
   CourseCard,
   Loading,
   SubHeader,
 } from '../generic';
-import { useCourseDiscovery } from '../data/course-discovery/hooks';
-import { DEFAULT_PAGE_INDEX, DEFAULT_PAGE_SIZE } from '../data/course-discovery/constants';
 import { transformResultsForTable, transformAggregationsToFilterChoices } from './utils';
+import { useFilterState } from './hooks/useFilterState';
 import messages from './messages';
 
 const CatalogPage = () => {
@@ -33,18 +32,23 @@ const CatalogPage = () => {
   } = useCourseDiscovery();
   const { data: frontendParams } = useFrontendParams();
   const isMedium = useMediaQuery({ maxWidth: breakpoints.large.maxWidth });
-  const [pageIndex, setPageIndex] = useState(DEFAULT_PAGE_INDEX);
+
+  const {
+    pageIndex,
+    filterState,
+    handleFetchData,
+    resetFilterProgress,
+  } = useFilterState(fetchData);
 
   useEffect(() => {
-    fetchData({ pageIndex, pageSize: DEFAULT_PAGE_SIZE });
-  }, [pageIndex, fetchData]);
+    fetchData({ pageIndex: DEFAULT_PAGE_INDEX, pageSize: DEFAULT_PAGE_SIZE });
+  }, [fetchData]);
 
-  const handleFetchData = useCallback((params) => {
-    if (params.pageIndex !== pageIndex) {
-      setPageIndex(params.pageIndex);
+  useEffect(() => {
+    if (!isFetching && filterState.isFilterChangeInProgress) {
+      resetFilterProgress();
     }
-    fetchData(params);
-  }, [pageIndex, fetchData]);
+  }, [isFetching, filterState.isFilterChangeInProgress, resetFilterProgress]);
 
   const tableData = useMemo(
     () => transformResultsForTable(courseData?.results),

--- a/src/сatalog/CatalogPage.tsx
+++ b/src/сatalog/CatalogPage.tsx
@@ -56,7 +56,7 @@ const CatalogPage = () => {
   );
 
   const tableColumns = useMemo(
-    () => transformAggregationsToFilterChoices(courseData?.aggs),
+    () => transformAggregationsToFilterChoices(courseData?.aggs, intl),
     [courseData],
   );
 

--- a/src/сatalog/CatalogPage.tsx
+++ b/src/сatalog/CatalogPage.tsx
@@ -1,6 +1,9 @@
 import {
+  useState, useEffect, useCallback, useMemo,
+} from 'react';
+import {
   Container, Alert, SearchField, DataTable, TextFilter,
-  CardView, CheckboxFilter, useMediaQuery, breakpoints,
+  CardView, useMediaQuery, breakpoints,
 } from '@openedx/paragon';
 import { ErrorPage } from '@edx/frontend-platform/react';
 import { getConfig } from '@edx/frontend-platform';
@@ -16,7 +19,7 @@ import {
 } from '../generic';
 import { useCourseDiscovery } from '../data/course-discovery/hooks';
 import { DEFAULT_PAGE_INDEX, DEFAULT_PAGE_SIZE } from '../data/course-discovery/constants';
-import { transformResultsForTable } from './utils';
+import { transformResultsForTable, transformAggregationsToFilterChoices } from './utils';
 import messages from './messages';
 
 const CatalogPage = () => {
@@ -25,9 +28,33 @@ const CatalogPage = () => {
     data: courseData,
     isLoading,
     isError,
+    fetchData,
+    isFetching,
   } = useCourseDiscovery();
   const { data: frontendParams } = useFrontendParams();
   const isMedium = useMediaQuery({ maxWidth: breakpoints.large.maxWidth });
+  const [pageIndex, setPageIndex] = useState(DEFAULT_PAGE_INDEX);
+
+  useEffect(() => {
+    fetchData({ pageIndex, pageSize: DEFAULT_PAGE_SIZE });
+  }, [pageIndex, fetchData]);
+
+  const handleFetchData = useCallback((params) => {
+    if (params.pageIndex !== pageIndex) {
+      setPageIndex(params.pageIndex);
+    }
+    fetchData(params);
+  }, [pageIndex, fetchData]);
+
+  const tableData = useMemo(
+    () => transformResultsForTable(courseData?.results),
+    [courseData],
+  );
+
+  const tableColumns = useMemo(
+    () => transformAggregationsToFilterChoices(courseData?.aggs),
+    [courseData],
+  );
 
   if (isLoading) {
     return (
@@ -50,6 +77,7 @@ const CatalogPage = () => {
   }
 
   const totalCourses = courseData?.results?.length ?? 0;
+  const pageCount = Math.ceil((courseData?.total || totalCourses) / DEFAULT_PAGE_SIZE);
 
   return (
     <Container className="container-xl pt-5.5">
@@ -71,41 +99,24 @@ const CatalogPage = () => {
             placeholder={intl.formatMessage(messages.searchPlaceholder)}
           />
           <DataTable
-            isLoading={isLoading}
+            isLoading={isFetching}
             showFiltersInSidebar={!isMedium}
             isFilterable={frontendParams?.enableCourseDiscovery}
             isSortable
             isPaginated
+            manualFilters
+            manualPagination
             defaultColumnValues={{ Filter: TextFilter }}
-            itemCount={totalCourses}
-            initialState={{ pageSize: DEFAULT_PAGE_SIZE, pageIndex: DEFAULT_PAGE_INDEX }}
-            data={transformResultsForTable(courseData?.results)}
-            columns={[
-              {
-                Header: 'Language',
-                accessor: 'language',
-                Filter: CheckboxFilter,
-                filter: 'includesValue',
-                filterChoices: [{
-                  name: 'English',
-                  number: 2,
-                  value: 'English',
-                },
-                {
-                  name: 'Ukrainian',
-                  number: 2,
-                  value: 'Ukrainian',
-                },
-                {
-                  name: 'Spanish',
-                  number: 1,
-                  value: 'Spanish',
-                }],
-              },
-            ]}
+            itemCount={courseData?.total || totalCourses}
+            pageSize={DEFAULT_PAGE_SIZE}
+            pageCount={pageCount}
+            initialState={{ pageSize: DEFAULT_PAGE_SIZE, pageIndex }}
+            data={tableData}
+            columns={tableColumns}
+            fetchData={handleFetchData}
           >
             <DataTable.TableControlBar />
-            <CardView CardComponent={CourseCard} />
+            <CardView CardComponent={CourseCard} skeletonCardCount={3} />
             <DataTable.EmptyTable content={intl.formatMessage(messages.noResultsFound)} />
             <DataTable.TableFooter />
           </DataTable>

--- a/src/сatalog/hooks/useFilterState.ts
+++ b/src/сatalog/hooks/useFilterState.ts
@@ -1,0 +1,55 @@
+import { useState, useCallback } from 'react';
+
+import { DEFAULT_PAGE_INDEX } from '@src/data/course-discovery/constants';
+
+const INITIAL_FILTER_STATE = {
+  previousFilters: null,
+  isFilterChangeInProgress: false,
+};
+
+export const useFilterState = (fetchData) => {
+  const [pageIndex, setPageIndex] = useState(DEFAULT_PAGE_INDEX);
+  const [filterState, setFilterState] = useState(INITIAL_FILTER_STATE);
+
+  const handleFetchData = useCallback((params) => {
+    const { pageIndex: newPageIndex, filters: newFilters } = params;
+
+    const hasFilters = newFilters && Object.keys(newFilters).length > 0;
+    const hadFilters = filterState.previousFilters && Object.keys(filterState.previousFilters).length > 0;
+    const filtersChanged = filterState.previousFilters !== null
+      && JSON.stringify(newFilters) !== JSON.stringify(filterState.previousFilters);
+    const isFirstFilterApplied = !hadFilters && hasFilters;
+
+    if (filterState.isFilterChangeInProgress) {
+      return;
+    }
+
+    if (filtersChanged || isFirstFilterApplied) {
+      setFilterState(prev => ({
+        ...prev,
+        isFilterChangeInProgress: true,
+        previousFilters: newFilters || {},
+      }));
+      setPageIndex(0);
+      fetchData({ ...params, pageIndex: 0 });
+      return;
+    }
+
+    setPageIndex(newPageIndex);
+    fetchData(params);
+  }, [fetchData, filterState.previousFilters, filterState.isFilterChangeInProgress]);
+
+  const resetFilterProgress = useCallback(() => {
+    setFilterState(prev => ({
+      ...prev,
+      isFilterChangeInProgress: false,
+    }));
+  }, []);
+
+  return {
+    pageIndex,
+    filterState,
+    handleFetchData,
+    resetFilterProgress,
+  };
+};

--- a/src/сatalog/messages.ts
+++ b/src/сatalog/messages.ts
@@ -36,6 +36,21 @@ const messages = defineMessages({
     defaultMessage: 'No results found',
     description: 'No results found.',
   },
+  organizations: {
+    id: 'category.catalog.filter.organizations',
+    defaultMessage: 'Organizations',
+    description: 'Organizations filter.',
+  },
+  languages: {
+    id: 'category.catalog.filter.languages',
+    defaultMessage: 'Languages',
+    description: 'Languages filter.',
+  },
+  courseTypes: {
+    id: 'category.catalog.filter.course-types',
+    defaultMessage: 'Course types',
+    description: 'Course types filter.',
+  },
 });
 
 export default messages;

--- a/src/сatalog/utils.ts
+++ b/src/сatalog/utils.ts
@@ -1,7 +1,9 @@
 import { CheckboxFilter } from '@openedx/paragon';
+import { IntlShape } from '@edx/frontend-platform/i18n';
 
 import type { CourseDiscoveryResponse, Aggregations } from '../data/course-discovery/types';
 import type { TransformedCourseItem } from './types';
+import messages from './messages';
 
 /**
  * Transforms course discovery results into a format suitable for DataTable display.
@@ -26,13 +28,13 @@ export const transformResultsForTable = (results: CourseDiscoveryResponse['resul
 /**
  * Transforms aggregations into filter choices for DataTable.
  */
-export const transformAggregationsToFilterChoices = (aggregations: Aggregations | undefined) => {
+export const transformAggregationsToFilterChoices = (aggregations: Aggregations | undefined, intl: IntlShape) => {
   if (!aggregations) { return []; }
 
   const headerMap: Record<string, string> = {
-    org: 'Organizations',
-    language: 'Languages',
-    modes: 'Course Types',
+    org: intl.formatMessage(messages.organizations),
+    language: intl.formatMessage(messages.languages),
+    modes: intl.formatMessage(messages.courseTypes),
   };
 
   return Object.entries(aggregations).map(([key, aggValue]) => {

--- a/src/сatalog/utils.ts
+++ b/src/сatalog/utils.ts
@@ -1,4 +1,6 @@
-import type { CourseDiscoveryResponse } from '../data/course-discovery/types';
+import { CheckboxFilter } from '@openedx/paragon';
+
+import type { CourseDiscoveryResponse, Aggregations } from '../data/course-discovery/types';
 import type { TransformedCourseItem } from './types';
 
 /**
@@ -19,4 +21,34 @@ export const transformResultsForTable = (results: CourseDiscoveryResponse['resul
     index: item.index,
     type: item.type,
   }));
+};
+
+/**
+ * Transforms aggregations into filter choices for DataTable.
+ */
+export const transformAggregationsToFilterChoices = (aggregations: Aggregations | undefined) => {
+  if (!aggregations) { return []; }
+
+  const headerMap: Record<string, string> = {
+    org: 'Organizations',
+    language: 'Languages',
+    modes: 'Course Types',
+  };
+
+  return Object.entries(aggregations).map(([key, aggValue]) => {
+    const terms = aggValue.terms || {};
+    const filterChoices = Object.entries(terms).map(([termKey, count]) => ({
+      name: termKey,
+      number: count,
+      value: termKey,
+    }));
+
+    return {
+      Header: headerMap[key] || key.charAt(0).toUpperCase() + key.slice(1),
+      accessor: key,
+      Filter: CheckboxFilter,
+      filter: 'includesValue',
+      filterChoices,
+    };
+  });
 };


### PR DESCRIPTION
> [!NOTE]
> Dependencies:
> - [ ] [BE - feat: [FC-86] implement index page config api](https://github.com/openedx/edx-platform/pull/36842)
> - [ ] [BE - feat: [FC-86] add sorting feature for engines](https://github.com/openedx/edx-search/pull/205)
> - [ ] [BE - feat: [FC-86] extend courseware api with new fields](https://github.com/openedx/edx-platform/pull/36845)
> - [ ] [BE - feat: [FC-86] add org_image_url to course_discovery index FC-86](https://github.com/openedx/edx-platform/pull/36846)
> - [ ] [BE - feat: [FC-86] Add Sorting Feature for Engines](https://github.com/openedx/edx-search/pull/205)
> - [ ] [BE - feat: [FC-86] create new version of course discovery API](https://github.com/raccoongang/edx-search/pull/13)
> - [ ] [BE - feat: [FC-86] implement multivalue faceted search using Meilisearch and Elasticsearch](https://github.com/openedx/edx-search/pull/213)
> - [ ] [FE - feat: [FC-86] Home page banner section](https://github.com/openedx/frontend-app-catalog/pull/7)
> - [ ] [FE - feat: [FC-86] Added Home page courses list](https://github.com/raccoongang/frontend-app-catalog/pull/16)
> - [ ] [FE - feat: [FC-86] Added plugin-slots for Home page](https://github.com/raccoongang/frontend-app-catalog/pull/17)
> - [ ] [FE - feat: [FC-86] Created Intro section for Course About page](https://github.com/raccoongang/frontend-app-catalog/pull/19)
> - [ ] [FE - feat: [FC-86] Added Course About sidebar](https://github.com/raccoongang/frontend-app-catalog/pull/20)
> - [ ] [feat: [FC-86] Added course overview and updated sidebar](https://github.com/raccoongang/frontend-app-catalog/pull/21)
>
> Dependent PRs:
> - [feat: [FC-86] Added course search for DataTable](https://github.com/raccoongang/frontend-app-catalog/pull/24)

> [!WARNING]  
> - [ ] Merging all dependencies

### Description

This PR adds course filtering for the Course Catalog page.

### Useful information

[Figma design](https://www.figma.com/design/wbp0938O3w2pCbrP3U3jDL/MFE---Plug-in-slots-proposal?node-id=0-1&p=f&t=bxIG84LnDDm8kJmQ-0)

#### Initial setup

1. Clone and install the tutor-mfe plugin from [the draft PR](https://github.com/overhangio/tutor-mfe/pull/259) that adds support for Catalog MFE.
2. Go to http://apps.local.openedx.io:1998/catalog/courses

#### How Has This Been Tested?

1. Go to Course Catalog page (`http://apps.local.openedx.io:1998/catalog/courses`).
2. When loading the page, a loader (spinner) is displayed.
3. If there are no courses, an alert is displayed with information about this.
4. Course cards are displayed inside the DataTable component (logic related to filtering courses will be provided later).
5. The Form.Control component is displayed correctly (search logic will be added later)
6. The page is displayed incorrectly on mobile screens.
7. If an error occurred while loading the page content - an error message is displayed (message taken from [LearnerDashboard MFE](https://github.com/openedx/frontend-app-learner-dashboard/blob/master/src/App.jsx#L87)).

![image](https://github.com/user-attachments/assets/d01acd79-f5f6-413c-ae84-8221358f7b6b)

8. Create a new course from Studio.
9. Check the display of the course card on the new Course Catalog page.
10. If there is no course image, the default image is displayed.

![image](https://github.com/user-attachments/assets/b5900fd7-20de-45aa-8d61-306a1333b784)

11. Through the Schedule and Details page, load the course image and check on the Course Catalog page that the image is displayed.
12. By clicking on the course card, the New Course About page opens (`http://apps.local.openedx.io:1998/catalog/courses/<course_id>/about`) without full page reloading (React Router).